### PR TITLE
[setting] application.yml 파일에서 DB 관련 설정 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     //Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/kernel360/kernelsquare/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/member/controller/MemberControllerTest.java
@@ -71,7 +71,7 @@ public class MemberControllerTest {
 				.content(jsonRequest))
 			.andExpect(status().isOk())
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-			.andExpect(jsonPath("$.code").value(MEMBER_INFO_UPDATED.getStatus().value()))
+			.andExpect(jsonPath("$.code").value(MEMBER_INFO_UPDATED.getCode()))
 			.andExpect(jsonPath("$.msg").value(MEMBER_INFO_UPDATED.getMsg()));
 
 		//verify
@@ -98,7 +98,7 @@ public class MemberControllerTest {
 				.content(newPassword))
 			.andExpect(status().isOk())
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-			.andExpect(jsonPath("$.code").value(MEMBER_PASSWORD_UPDATED.getStatus().value()))
+			.andExpect(jsonPath("$.code").value(MEMBER_PASSWORD_UPDATED.getCode()))
 			.andExpect(jsonPath("$.msg").value(MEMBER_PASSWORD_UPDATED.getMsg()));
 
 		//verify
@@ -122,7 +122,7 @@ public class MemberControllerTest {
 				.characterEncoding("UTF-8"))
 			.andExpect(status().isNotFound())
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-			.andExpect(jsonPath("$.code").value(MEMBER_NOT_FOUND.getStatus().value()))
+			.andExpect(jsonPath("$.code").value(MEMBER_NOT_FOUND.getCode()))
 			.andExpect(jsonPath("$.msg").value(MEMBER_NOT_FOUND.getMsg()));
 
 		//verify
@@ -146,7 +146,7 @@ public class MemberControllerTest {
 				.characterEncoding("UTF-8"))
 			.andExpect(status().isOk())
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-			.andExpect(jsonPath("$.code").value(MEMBER_FOUND.getStatus().value()))
+			.andExpect(jsonPath("$.code").value(MEMBER_FOUND.getCode()))
 			.andExpect(jsonPath("$.msg").value(MEMBER_FOUND.getMsg()))
 			.andExpect(jsonPath("$.data.nickname").value(testMember.getNickname()))
 			.andExpect(jsonPath("$.data.experience").value(testMember.getExperience()))
@@ -174,7 +174,7 @@ public class MemberControllerTest {
 				.characterEncoding("UTF-8"))
 			.andExpect(status().isOk())
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-			.andExpect(jsonPath("$.code").value(MEMBER_DELETED.getStatus().value()))
+			.andExpect(jsonPath("$.code").value(MEMBER_DELETED.getCode()))
 			.andExpect(jsonPath("$.msg").value(MEMBER_DELETED.getMsg()));
 
 		//verify

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,7 +1,10 @@
 spring:
   datasource:
-    url: ${LOCAL_DB_URL}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
-    driver-class-name: com.mysql.cj.jdbc.Driver
+#    ToDo service test 부분 mocking 작업이 끝나면 추가 작업할 예정
+#    url: ${TEST_DB_URL}
+#    url: jdbc:h2:mem:test_kernel_square;MODE=MySQL
+    url: jdbc:h2:mem:test_kernel_square
+    driver-class-name: org.h2.Driver
     username: ${LOCAL_DB_HOST}
     password: ${LOCAL_DB_PASSWORD}
 
@@ -13,6 +16,9 @@ spring:
       hibernate:
         #        show-sql: true
         format_sql: true
+#        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+
+    database-platform: org.hibernate.dialect.H2Dialect
 
   jackson:
     property-naming-strategy: SNAKE_CASE


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #12 

## 개요
> main과 test의 application.yml 파일을 DB 관련 설정을 상황에 맞게 세팅하기 위함

## 상세 내용
- 실제 서비스 DB URL을 기존 URL에서 db이름까지 환경변수로 받음
- 테스트는 기본 h2 인메모리 db를 사용
- MemberControllerTest파일에서 실패하는 코드 수정
