### PR TITLE
[feat] 단일 질문에 대한 복수 답변 조회 기능

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerController.java
@@ -1,0 +1,29 @@
+package com.kernel360.kernelsquare.domain.answer.controller;
+
+import com.kernel360.kernelsquare.domain.answer.dto.FindAnswerResponse;
+import com.kernel360.kernelsquare.domain.answer.service.AnswerService;
+import com.kernel360.kernelsquare.global.common_response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.kernel360.kernelsquare.global.common_response.response.code.AnswerResponseCode.ANSWERS_ALL_FOUND;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AnswerController {
+
+    private final AnswerService answerService;
+
+    @GetMapping("/questions/{questionId}/answers")
+    public ResponseEntity<ApiResponse<List<FindAnswerResponse>>> findAllAnswers(@PathVariable Long questionId) {
+        List<FindAnswerResponse> findAnswerResponses = answerService.findAllAnswer(questionId);
+        return ResponseEntity.ok(ApiResponse.of(ANSWERS_ALL_FOUND, findAnswerResponses));
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerController.java
@@ -3,6 +3,7 @@ package com.kernel360.kernelsquare.domain.answer.controller;
 import com.kernel360.kernelsquare.domain.answer.dto.FindAnswerResponse;
 import com.kernel360.kernelsquare.domain.answer.service.AnswerService;
 import com.kernel360.kernelsquare.global.common_response.ApiResponse;
+import com.kernel360.kernelsquare.global.common_response.ResponseEntityFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +25,6 @@ public class AnswerController {
     @GetMapping("/questions/{questionId}/answers")
     public ResponseEntity<ApiResponse<List<FindAnswerResponse>>> findAllAnswers(@PathVariable Long questionId) {
         List<FindAnswerResponse> findAnswerResponses = answerService.findAllAnswer(questionId);
-        return ResponseEntity.ok(ApiResponse.of(ANSWERS_ALL_FOUND, findAnswerResponses));
+        return ResponseEntityFactory.toResponseEntity(ANSWERS_ALL_FOUND, findAnswerResponses);
     }
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/answer/dto/FindAnswerResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/answer/dto/FindAnswerResponse.java
@@ -1,0 +1,31 @@
+package com.kernel360.kernelsquare.domain.answer.dto;
+
+import com.kernel360.kernelsquare.domain.answer.entity.Answer;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record FindAnswerResponse(
+    Long id,
+    Long questionId,
+    String content,
+    String rankImageUrl,
+    String createdBy,
+    String imageUrl,
+    String createdDate,
+    Long voteCount
+) {
+    public static FindAnswerResponse from(Answer answer) {
+        return new FindAnswerResponse(
+                answer.getId(),
+                answer.getQuestion().getId(),
+                answer.getContent(),
+                "rankUrl",// answer.getRank().getImageUrl(),
+                answer.getMember().getNickname(),
+                answer.getImageUrl(),
+                answer.getCreatedDate().toLocalDate().toString(),
+                answer.getVoteCount()
+        );
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/answer/dto/FindAnswerResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/answer/dto/FindAnswerResponse.java
@@ -21,7 +21,7 @@ public record FindAnswerResponse(
                 answer.getId(),
                 answer.getQuestion().getId(),
                 answer.getContent(),
-                "rankUrl",// answer.getRank().getImageUrl(),
+                "rankUrl",
                 answer.getMember().getNickname(),
                 answer.getImageUrl(),
                 answer.getCreatedDate().toLocalDate().toString(),

--- a/src/main/java/com/kernel360/kernelsquare/domain/answer/dto/FindAnswerResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/answer/dto/FindAnswerResponse.java
@@ -11,8 +11,9 @@ public record FindAnswerResponse(
     Long questionId,
     String content,
     String rankImageUrl,
+    String memberImageUrl,
     String createdBy,
-    String imageUrl,
+    String answerImageUrl,
     String createdDate,
     Long voteCount
 ) {
@@ -22,6 +23,7 @@ public record FindAnswerResponse(
                 answer.getQuestion().getId(),
                 answer.getContent(),
                 "rankUrl",
+                answer.getMember().getImageUrl(),
                 answer.getMember().getNickname(),
                 answer.getImageUrl(),
                 answer.getCreatedDate().toLocalDate().toString(),

--- a/src/main/java/com/kernel360/kernelsquare/domain/answer/entity/Answer.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/answer/entity/Answer.java
@@ -1,26 +1,24 @@
 package com.kernel360.kernelsquare.domain.answer.entity;
 
 import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.member_answer_vote.entity.MemberAnswerVote;
 import com.kernel360.kernelsquare.domain.question.entity.Question;
 import com.kernel360.kernelsquare.domain.rank.entity.Rank;
 import com.kernel360.kernelsquare.global.entity.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.ConstraintMode;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity(name = "answer")
 @Getter
+@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Answer extends BaseEntity {
 	@Id
@@ -41,4 +39,23 @@ public class Answer extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "question_id", columnDefinition = "bigint", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
 	private Question question;
+
+	@OneToMany(mappedBy = "answer")
+	private List<MemberAnswerVote> memberAnswerVote = new ArrayList<>();
+
+	@Lob
+	@Column(name = "content", columnDefinition = "text")
+	private String content;
+
+	@Column(name = "vote_count", columnDefinition = "smallint")
+	private Long voteCount;
+
+	@Builder
+	private Answer(String imageUrl, String content, Long voteCount, Member member, Question question) {
+		this.content = content;
+		this.voteCount = voteCount;
+		this.imageUrl = imageUrl;
+		this.member = member;
+		this.question = question;
+	}
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/answer/entity/Answer.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/answer/entity/Answer.java
@@ -43,7 +43,6 @@ public class Answer extends BaseEntity {
 	@OneToMany(mappedBy = "answer")
 	private List<MemberAnswerVote> memberAnswerVote = new ArrayList<>();
 
-	@Lob
 	@Column(name = "content", columnDefinition = "text")
 	private String content;
 

--- a/src/main/java/com/kernel360/kernelsquare/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/answer/repository/AnswerRepository.java
@@ -1,0 +1,13 @@
+package com.kernel360.kernelsquare.domain.answer.repository;
+
+import com.kernel360.kernelsquare.domain.answer.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+    @Query("SELECT a FROM answer a WHERE a.question.id = :questionId ORDER BY a.createdDate DESC")
+    List<Answer> findAnswersByQuestionIdSortedByCreationDate(@Param("questionId") Long questionId);
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/answer/service/AnswerService.java
@@ -1,0 +1,25 @@
+package com.kernel360.kernelsquare.domain.answer.service;
+
+import com.kernel360.kernelsquare.domain.answer.dto.FindAnswerResponse;
+import com.kernel360.kernelsquare.domain.answer.repository.AnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerService {
+    private final AnswerRepository answerRepository;
+
+    @Transactional(readOnly = true)
+    public List<FindAnswerResponse> findAllAnswer(Long questionId) {
+        return answerRepository.findAnswersByQuestionIdSortedByCreationDate(questionId)
+                .stream()
+                .map(FindAnswerResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/AnswerResponseCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/AnswerResponseCode.java
@@ -12,7 +12,7 @@ public enum AnswerResponseCode implements ResponseCode {
 	ANSWER_UPDATE_NOT_AUTHORIZED(HttpStatus.FORBIDDEN,
 			AnswerServiceStatus.ANSWER_UPDATE_NOT_AUTHORIZED, "답변을 수정할 권한이 없습니다."),
 
-	ANSWER_CREATED(HttpStatus.OK, AnswerServiceStatus.ANSWER_CREATED, "답변 생성 성공"),
+	ANSWER_CREATED(HttpStatus.CREATED, AnswerServiceStatus.ANSWER_CREATED, "답변 생성 성공"),
 	ANSWERS_ALL_FOUND(HttpStatus.OK, AnswerServiceStatus.ANSWERS_ALL_FOUND, "질문에 대한 모든 답변 조회 성공"),
 	ANSWER_UPDATED(HttpStatus.OK, AnswerServiceStatus.ANSWER_UPDATED, "답변 수정 성공"),
 	ANSWER_DELETED(HttpStatus.OK, AnswerServiceStatus.ANSWER_DELETED, "답변 삭제 성공"),

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/AnswerResponseCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/AnswerResponseCode.java
@@ -16,7 +16,7 @@ public enum AnswerResponseCode implements ResponseCode {
 	ANSWERS_ALL_FOUND(HttpStatus.OK, AnswerServiceStatus.ANSWERS_ALL_FOUND, "질문에 대한 모든 답변 조회 성공"),
 	ANSWER_UPDATED(HttpStatus.OK, AnswerServiceStatus.ANSWER_UPDATED, "답변 수정 성공"),
 	ANSWER_DELETED(HttpStatus.OK, AnswerServiceStatus.ANSWER_DELETED, "답변 삭제 성공"),
-	VOTE_CREATED(HttpStatus.OK, AnswerServiceStatus.VOTE_CREATED, "투표 생성"),
+	VOTE_CREATED(HttpStatus.CREATED, AnswerServiceStatus.VOTE_CREATED, "투표 생성"),
 	VOTE_DELETED(HttpStatus.OK, AnswerServiceStatus.VOTE_DELETED, "투표 삭제");
 
 	private final HttpStatus code;

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/AnswerResponseCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/AnswerResponseCode.java
@@ -1,0 +1,40 @@
+package com.kernel360.kernelsquare.global.common_response.response.code;
+
+import com.kernel360.kernelsquare.global.common_response.service.code.AnswerServiceStatus;
+import com.kernel360.kernelsquare.global.common_response.service.code.ServiceStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AnswerResponseCode implements ResponseCode {
+	ANSWER_CREATION_NOT_AUTHORIZED(HttpStatus.FORBIDDEN,
+			AnswerServiceStatus.ANSWER_CREATION_NOT_AUTHORIZED, "답변을 입력할 권한이 없습니다."),
+	ANSWER_UPDATE_NOT_AUTHORIZED(HttpStatus.FORBIDDEN,
+			AnswerServiceStatus.ANSWER_UPDATE_NOT_AUTHORIZED, "답변을 수정할 권한이 없습니다."),
+
+	ANSWER_CREATED(HttpStatus.OK, AnswerServiceStatus.ANSWER_CREATED, "답변 생성 성공"),
+	ANSWERS_ALL_FOUND(HttpStatus.OK, AnswerServiceStatus.ANSWERS_ALL_FOUND, "질문에 대한 모든 답변 조회 성공"),
+	ANSWER_UPDATED(HttpStatus.OK, AnswerServiceStatus.ANSWER_UPDATED, "답변 수정 성공"),
+	ANSWER_DELETED(HttpStatus.OK, AnswerServiceStatus.ANSWER_DELETED, "답변 삭제 성공"),
+	VOTE_CREATED(HttpStatus.OK, AnswerServiceStatus.VOTE_CREATED, "투표 생성"),
+	VOTE_DELETED(HttpStatus.OK, AnswerServiceStatus.VOTE_DELETED, "투표 삭제");
+
+	private final HttpStatus code;
+	private final ServiceStatus serviceStatus;
+	private final String msg;
+
+	@Override
+	public HttpStatus getStatus() {
+		return code;
+	}
+
+	@Override
+	public Integer getCode() {
+		return serviceStatus.getServiceStatus();
+	}
+
+	@Override
+	public String getMsg() {
+		return msg;
+	}
+}

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/QuestionResponseCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/QuestionResponseCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum QuestionResponseCode implements ResponseCode {
-    QUESTION_CREATED(HttpStatus.OK, QuestionServiceStatus.QUESTION_CREATED,"질문 생성 성공"),
+    QUESTION_CREATED(HttpStatus.CREATED, QuestionServiceStatus.QUESTION_CREATED,"질문 생성 성공"),
     QUESTION_FOUND(HttpStatus.OK, QuestionServiceStatus.QUESTION_FOUND,"질문 조회 성공"),
     QUESTION_ALL_FOUND(HttpStatus.OK,QuestionServiceStatus.QUESTION_ALL_FOUND, "모든 질문 조회 성공"),
     QUESTION_UPDATED(HttpStatus.OK,QuestionServiceStatus.QUESTION_UPDATED , "질문 수정 성공"),

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/AnswerServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/AnswerServiceStatus.java
@@ -1,0 +1,23 @@
+package com.kernel360.kernelsquare.global.common_response.service.code;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AnswerServiceStatus implements ServiceStatus{
+    ANSWER_CREATION_NOT_AUTHORIZED(2120),
+    ANSWER_UPDATE_NOT_AUTHORIZED(2121),
+
+    ANSWER_CREATED(2150),
+    ANSWERS_ALL_FOUND(2151),
+    ANSWER_UPDATED(2152),
+    ANSWER_DELETED(2153),
+    VOTE_CREATED(2154),
+    VOTE_DELETED(2155);
+
+    private final Integer code;
+
+    @Override
+    public Integer getServiceStatus() {
+        return code;
+    }
+}

--- a/src/test/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerControllerTest.java
@@ -1,0 +1,105 @@
+package com.kernel360.kernelsquare.domain.answer.controller;
+
+import com.kernel360.kernelsquare.domain.answer.dto.FindAnswerResponse;
+import com.kernel360.kernelsquare.domain.answer.entity.Answer;
+import com.kernel360.kernelsquare.domain.answer.service.AnswerService;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.question.entity.Question;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.kernel360.kernelsquare.global.common_response.response.code.AnswerResponseCode.ANSWERS_ALL_FOUND;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@DisplayName("답변 컨트롤러 단위 테스트")
+@WebMvcTest(AnswerController.class)
+public class AnswerControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private AnswerService answerService;
+    private final Long testQuestionId = 1L;
+    private final Question testQuestion = Question
+            .builder()
+            .title("Test Question")
+            .content("Test Content")
+            .imageUrl("S3:TestImage")
+            .closedStatus(false)
+            .build();
+
+    private final Member testMember = Member
+            .builder()
+            .nickname("hongjugwang")
+            .email("jugwang@naver.com")
+            .password("hashedPassword")
+            .experience(10000L)
+            .introduction("hi, i'm hongjugwang.")
+            .imageUrl("s3:qwe12fasdawczx")
+            .build();
+
+    private final Answer testAnswer = Answer
+            .builder()
+            .content("Test Answer Content")
+            .voteCount(10L)
+            .imageUrl("s3:AnswerImageURL")
+            .member(testMember)
+            .question(testQuestion)
+            .build();
+
+    private final FindAnswerResponse findAnswerResponse = FindAnswerResponse
+            .builder()
+            .id(1L)
+            .questionId(1L)
+            .content(testAnswer.getContent())
+            .rankImageUrl("s3:RankURL")
+            .createdBy("HongJuGwang")
+            .imageUrl(testAnswer.getImageUrl())
+            .createdDate(LocalDate.now().toString())
+            .voteCount(testAnswer.getVoteCount())
+            .build();
+
+    private List<FindAnswerResponse> answerResponseList = new ArrayList<>();
+
+    @Test
+    @WithMockUser
+    @DisplayName("답변 조회 성공시, 200 OK, 메시지, 답변정보를 반환한다.")
+    void testFindAllAnswers() throws Exception {
+        //given
+        answerResponseList.add(findAnswerResponse);
+        doReturn(answerResponseList)
+                .when(answerService)
+                .findAllAnswer(anyLong());
+
+        //when & then
+        mockMvc.perform(get("/api/v1/questions/" + testQuestionId + "/answers")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().is(ANSWERS_ALL_FOUND.getStatus().value()))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(ANSWERS_ALL_FOUND.getCode()))
+                .andExpect(jsonPath("$.msg").value(ANSWERS_ALL_FOUND.getMsg()))
+                .andExpect(jsonPath("$.data[0].content").value(testAnswer.getContent()))
+                .andExpect(jsonPath("$.data[0].image_url").value(testAnswer.getImageUrl()))
+                .andExpect(jsonPath("$.data[0].vote_count").value(testAnswer.getVoteCount()));
+
+        //verify
+        verify(answerService, times(1)).findAllAnswer(anyLong());
+    }
+}

--- a/src/test/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerControllerTest.java
@@ -68,7 +68,8 @@ public class AnswerControllerTest {
             .content(testAnswer.getContent())
             .rankImageUrl("s3:RankURL")
             .createdBy("HongJuGwang")
-            .imageUrl(testAnswer.getImageUrl())
+            .answerImageUrl(testAnswer.getImageUrl())
+            .memberImageUrl(testMember.getImageUrl())
             .createdDate(LocalDate.now().toString())
             .voteCount(testAnswer.getVoteCount())
             .build();

--- a/src/test/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/answer/controller/AnswerControllerTest.java
@@ -97,7 +97,7 @@ public class AnswerControllerTest {
                 .andExpect(jsonPath("$.code").value(ANSWERS_ALL_FOUND.getCode()))
                 .andExpect(jsonPath("$.msg").value(ANSWERS_ALL_FOUND.getMsg()))
                 .andExpect(jsonPath("$.data[0].content").value(testAnswer.getContent()))
-                .andExpect(jsonPath("$.data[0].image_url").value(testAnswer.getImageUrl()))
+                .andExpect(jsonPath("$.data[0].answer_image_url").value(testAnswer.getImageUrl()))
                 .andExpect(jsonPath("$.data[0].vote_count").value(testAnswer.getVoteCount()));
 
         //verify

--- a/src/test/java/com/kernel360/kernelsquare/domain/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/answer/service/AnswerServiceTest.java
@@ -1,0 +1,110 @@
+package com.kernel360.kernelsquare.domain.answer.service;
+
+import com.kernel360.kernelsquare.domain.answer.dto.FindAnswerResponse;
+import com.kernel360.kernelsquare.domain.answer.entity.Answer;
+import com.kernel360.kernelsquare.domain.answer.repository.AnswerRepository;
+import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberRequest;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
+import com.kernel360.kernelsquare.domain.member.service.MemberService;
+import com.kernel360.kernelsquare.domain.question.entity.Question;
+import com.kernel360.kernelsquare.domain.question.repository.QuestionRepository;
+import com.kernel360.kernelsquare.global.common_response.error.code.MemberErrorCode;
+import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@DisplayName("회원 서비스 통합 테스트")
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+public class AnswerServiceTest {
+    @Autowired
+    private AnswerService answerService;
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    Long createdQuestionId;
+    Question testQuestion;
+
+    Long createdMemberId;
+    Member testMember;
+
+    List<Answer> testAnswers = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        Question question = createTestQuestion();
+        testQuestion = questionRepository.save(question);
+        createdQuestionId = testQuestion.getId();
+
+        for (int i=1; i<4; i++) {
+            testMember = memberRepository.save(createTestMember(i));
+            System.out.println(testMember.getId());
+            testAnswers.add(answerRepository.save(createTestAnswer((long) i, testMember, testQuestion)));
+        }
+    }
+
+    @Test
+    @DisplayName("질문에 대한 답변 조회")
+    void findAllAnswer() throws Exception {
+        //given
+        Long newQuestionId = createdQuestionId;
+        //when
+        List<FindAnswerResponse> newAnswerList = answerService.findAllAnswer(newQuestionId);
+        //then
+        assertThat(testAnswers.size()).isEqualTo(newAnswerList.size());
+    }
+
+
+    private Question createTestQuestion() {
+        return Question
+                .builder()
+                .title("Test Question")
+                .content("Test Content")
+                .imageUrl("S3:TestImage")
+                .closedStatus(false)
+                .build();
+    }
+
+    private Member createTestMember(int index) {
+        return Member
+                .builder()
+                .nickname("hongjugwang" + index)
+                .email("jugwang" + index + "@naver.com")
+                .password("hashedPassword")
+                .experience(10000L)
+                .introduction("hi, i'm hongjugwang.")
+                .imageUrl("s3:qwe12fasdawczx")
+                .build();
+    }
+
+    private Answer createTestAnswer(Long index, Member member, Question question) {
+        return Answer
+                .builder()
+                .content("Test Answer" + index)
+                .voteCount(index)
+                .imageUrl("S3:TestAnswer" + index)
+                .member(member)
+                .question(question)
+                .build();
+    }
+}


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
체크박스 Close : #14 에서 해당 질문에 대한 모든 답변 조회에 해당하는 기능

## 개요
> 기능 추가를 위한 Answer 도메인 기능 개발
> 서비스 상태 ENUM TYPE으로 정의 & 명세서 작성(https://www.notion.so/c54aec9cd60e47078d0d321b0472ae09)
> 해당 기능에 대한 테스트 코드 작성 및 동작 확인

## 상세 내용
- 리포지토리는 Answer 리스트를 반환
- 서비스는 DTO 매핑
  - Rank 부분은 우선 하드코딩
- 컨트롤러 API 명세대로 작동 (Talend API에서 확인됨) 