### PR TITLE
[feat] 로그 AOP 1차 완성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok'
 
+    //AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     //Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/com/kernel360/kernelsquare/global/aop/Logging.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/aop/Logging.java
@@ -1,0 +1,74 @@
+package com.kernel360.kernelsquare.global.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class Logging {
+    @Pointcut("execution(* com.kernel360.kernelsquare.domain.member.service.MemberService.*(..)) || " +
+        "execution(* com.kernel360.kernelsquare.domain.question.service.QuestionService.*(..))")
+    public void allController() {}
+
+    @Around("allController()")
+    public Object aroundServiceMethod(ProceedingJoinPoint joinPoint) throws Throwable {
+        Signature signature = joinPoint.getSignature();
+        String fileFullName = signature.getDeclaringTypeName(); // 파일 전체 이름을 가져옵니다.
+        String packageName = fileFullName.substring(0, fileFullName.lastIndexOf('.')); // 패키지 이름을 가져옵니다.
+        String className = fileFullName.substring(fileFullName.lastIndexOf('.')+1); // 클래스 이름을 가져옵니다.
+        String methodName = signature.getName(); // 메서드 이름을 가져옵니다.
+
+        try {
+            long startTime = System.currentTimeMillis();
+
+            log.info("Start - Package: " + packageName + ", Class: " + className + ", Method: " + methodName);
+
+            // 메서드 실행
+            Object result = joinPoint.proceed();
+
+            long endTime = System.currentTimeMillis();
+            long executionTime = endTime - startTime;
+
+            log.info("Method " + signature.toShortString() + " execution finished with duration " + executionTime + " ms");
+
+            return result;
+        } catch (Throwable e){
+            log.error("Method " + signature.toShortString() + " execution finished with error: " + e);
+
+            throw e;
+        }
+    }
+
+    //ToDo 일단은 레포지토리 메서드가 정상적으로 동작하면 DB에 반영됨을 전제로 함.
+    @Pointcut("execution(* com.kernel360.kernelsquare.domain.member.repository.MemberRepository.*(..)) || " +
+        "execution(* com.kernel360.kernelsquare.domain.question.repository.QuestionRepository.*(..))")
+    public void allRepositoty() {}
+
+    @Around("allRepositoty()")
+    public Object aroundRepositoryMethod(ProceedingJoinPoint joinPoint) throws Throwable {
+        Signature signature = joinPoint.getSignature();
+
+        try {
+            long startTime = System.currentTimeMillis();
+
+            Object result = joinPoint.proceed();
+
+            long endTime = System.currentTimeMillis();
+            long executionTime = endTime - startTime;
+
+            log.info("JPA " + signature.toShortString() + " execution time: " + executionTime + " ms");
+
+            return result;
+        } catch (Throwable e) {
+            log.error("JPA " + signature.toShortString() + " execution finished with error: " + e);
+
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/global/aop/Logging.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/aop/Logging.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 public class Logging {
+    //ToDo 로그 정책이 정해지면 리팩토링
     @Pointcut("execution(* com.kernel360.kernelsquare.domain.member.service.MemberService.*(..)) || " +
         "execution(* com.kernel360.kernelsquare.domain.question.service.QuestionService.*(..))")
     public void allController() {}
@@ -45,7 +46,7 @@ public class Logging {
         }
     }
 
-    //ToDo 일단은 레포지토리 메서드가 정상적으로 동작하면 DB에 반영됨을 전제로 함.
+    /*일단은 레포지토리 메서드가 정상적으로 동작하면 DB에 반영됨을 전제로 함.*/
     @Pointcut("execution(* com.kernel360.kernelsquare.domain.member.repository.MemberRepository.*(..)) || " +
         "execution(* com.kernel360.kernelsquare.domain.question.repository.QuestionRepository.*(..))")
     public void allRepositoty() {}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,131 @@
+<configuration scan="true" scanPeriod="60 seconds">
+    <property name="LOG_PATH" value="logs"/>
+    <property name="TRACE_LOG_PATH" value="trace/%d{yyyy-MM}/traceLog"/>
+    <property name="DEBUG_LOG_PATH" value="debug/%d{yyyy-MM}/debugLog"/>
+    <property name="INFO_LOG_PATH" value="info/%d{yyyy-MM}/infoLog"/>
+    <property name="WARN_LOG_PATH" value="warn/%d{yyyy-MM}/warnLog"/>
+    <property name="ERROR_LOG_PATH" value="error/%d{yyyy-MM}/errorLog"/>
+    <property name="CONSOLE_LOG_PATTERN" value="%green(%d{yyyy-MM-dd HH:mm:ss}:) %magenta([%thread]) %highlight(%-5level) %cyan(%logger) %yellow([%C.%M:%line]) - %msg%n"/>
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss}: [%thread] %-5level %logger [%C.%M:%line] - %msg%n"/>
+
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="TRACE_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>TRACE</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${TRACE_LOG_PATH}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>3GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
+            <maxFileSize>10MB</maxFileSize>
+        </rollingPolicy>
+
+    </appender>
+
+    <appender name="DEBUG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${DEBUG_LOG_PATH}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>3GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
+            <maxFileSize>10MB</maxFileSize>
+        </rollingPolicy>
+
+    </appender>
+
+    <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${INFO_LOG_PATH}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>3GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
+            <maxFileSize>10MB</maxFileSize>
+        </rollingPolicy>
+
+    </appender>
+
+    <appender name="WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${WARN_LOG_PATH}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>3GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
+            <maxFileSize>10MB</maxFileSize>
+        </rollingPolicy>
+
+    </appender>
+
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${ERROR_LOG_PATH}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>3GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
+            <maxFileSize>10MB</maxFileSize>
+        </rollingPolicy>
+
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="TRACE_FILE"/>
+        <appender-ref ref="DEBUG_FILE"/>
+        <appender-ref ref="INFO_FILE"/>
+        <appender-ref ref="WARN_FILE"/>
+        <appender-ref ref="ERROR_FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #16 

## 개요
> 필요한 로그를 파일로 남기기 위함

## 상세 내용
- 현재 logback.xml 파일에 로그에 대한 모든 설정을 넣어둠
- 현재 Member와 Quesiton의 모든 서비스 메서드 시작, 종료, 걸린 시간과 JPA 걸린 시간을 남김
- 서비스 메서드 시작은 Start 패키지명, 클래스명, 메서드명을 나타냅니다.
- 서비스 종료는 클래스명.메서드, 걸린시간을 나타냅니다.
- 서비스 에러는 클래스명.메서드, 캐치한 에러를 나타냅니다.
- JPA는 클래스명(현재는 전부 CrudRepository).메서드, 걸린시간을 나타냅니다.
- 로그 정책이 정해지면 리팩토링이 필수
