### PR TITLE
[refactor] 기술 스택 수정 서비스 로직에 예외 처리 로직 추가

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/tech_stack/repository/TechStackRepository.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/tech_stack/repository/TechStackRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface TechStackRepository extends JpaRepository<TechStack, Long> {
     Optional<TechStack> findBySkill(String skill);
+
+    boolean existsBySkill(String skill);
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/tech_stack/service/TechStackService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/tech_stack/service/TechStackService.java
@@ -40,15 +40,21 @@ public class TechStackService {
     }
 
     @Transactional
-    public void deleteTechStack(Long techStackId) {
-        techStackRepository.deleteById(techStackId);
-    }
-
-    @Transactional
     public void updateTechStack(Long techStackId, UpdateTechStackRequest updateTechStackRequest) {
         TechStack techStack = techStackRepository.findById(techStackId)
             .orElseThrow(() -> new BusinessException(TechStackErrorCode.TECH_STACK_NOT_FOUND));
 
+        boolean isSkillExists = techStackRepository.existsBySkill(updateTechStackRequest.skill());
+
+        if (isSkillExists) {
+            throw new BusinessException(TechStackErrorCode.TECH_STACK_ALREADY_EXISTED);
+        }
+
         techStack.update(updateTechStackRequest.skill());
+    }
+
+    @Transactional
+    public void deleteTechStack(Long techStackId) {
+        techStackRepository.deleteById(techStackId);
     }
 }

--- a/src/test/java/com/kernel360/kernelsquare/domain/tech_stack/repository/TechStackRepositoryTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/tech_stack/repository/TechStackRepositoryTest.java
@@ -35,4 +35,19 @@ class TechStackRepositoryTest {
         assertThat(findTechStack).isNotNull();
         assertThat(findTechStack).isEqualTo(saveTechStack);
     }
+
+    @Test
+    @DisplayName("기술 스택 existsBySkill 정상 작동 테스트")
+    void testExistsBySkill() {
+        //given
+        TechStack techStack = new TechStack(1L, "Python");
+
+        techStackRepository.save(techStack);
+
+        //when
+        boolean isSkillExists = techStackRepository.existsBySkill(techStack.getSkill());
+
+        //then
+        assertThat(isSkillExists).isTrue();
+    }
 }


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #52 

## 개요
> 이미 존재하는 기술 스택으로 수정하려고 할 때의 예외 처리를 구현하기 위함

## 상세 내용
- TechStackRepository에 기술 스택이 존재하는지 확인하는데 existsBySkill메서드를 추가
- existsBySkill가 true면 커스텀 예외 발생 시키고 그렇지 않다면 update를 함
- 추가적으로 서비스 부분에서 수정과 삭제의 코드 순서를 바꿈
