### PR TITLE
[bugfix] 이미지 URL 응답을 s3 주소가 빠진 상태로 보내는 문제

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/member/dto/FindMemberResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/member/dto/FindMemberResponse.java
@@ -1,5 +1,6 @@
 package com.kernel360.kernelsquare.domain.member.dto;
 
+import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 
 import lombok.Builder;
@@ -22,7 +23,7 @@ public record FindMemberResponse(
 			.nickname(member.getNickname())
 			.experience(member.getExperience())
 			.introduction(member.getIntroduction())
-			.imageUrl(member.getImageUrl())
+			.imageUrl(ImageUtils.makeImageUrl(member.getImageUrl()))
 			.level(member.getLevel().getName())
 			.build();
 	}

--- a/src/main/java/com/kernel360/kernelsquare/domain/question/dto/FindQuestionResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/question/dto/FindQuestionResponse.java
@@ -34,9 +34,9 @@ public record FindQuestionResponse(
             question.getClosedStatus(),
             member.getId(),
             member.getNickname(),
-            member.getImageUrl(),
+            ImageUtils.makeImageUrl(member.getImageUrl()),
             level.getName(),
-            level.getImageUrl(),
+            ImageUtils.makeImageUrl(level.getImageUrl()),
             question.getTechStackList().stream().map(x -> x.getTechStack().getSkill()).toList(),
             question.getCreatedDate(),
             question.getModifiedDate()

--- a/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
@@ -86,7 +86,7 @@ public class SecurityConfig {
 			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}").hasRole("USER")
 			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/password").hasRole("USER")
 
-			.requestMatchers(HttpMethod.POST, "/api/v1/questions/").hasRole("USER")
+			.requestMatchers(HttpMethod.POST, "/api/v1/questions").hasRole("USER")
 			.requestMatchers(HttpMethod.PUT, "/api/v1/questions/{questionId}").hasRole("USER")
 			.requestMatchers(HttpMethod.DELETE, "/api/v1/questions/{questionId}").hasRole("USER")
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,10 +1,10 @@
 INSERT INTO member (created_date, experience, level_id, modified_date, email, image_url, nickname, password,
                     introduction)
-VALUES ('2023-12-19T09:00:00', 1, 1, '2023-12-19T09:00:00', 'email@example.com', 'example/image.jpg', 'nickname', 'password',
-        'introduction');
+VALUES ('2023-12-19T09:00:00', 0, 1, '2023-12-19T09:00:00', 'duck@example.com', 'member/1e47ea4d-a2cb-4de7-b7e4-a0f7bd1fa24cduck.png',
+        '자바덕', '$2a$10$OiSze5PH.QQ1uH7xWp.trOAbmv6rbi6foM7HsyDrVxn8RtZDMfWs.', 'introduction');
 
 INSERT INTO question (closed_status, created_date, id, member_id, modified_date, view_count, content, image_url, title)
-VALUES (1, '2023-12-19T09:00:00', 1, 1, '2023-12-21T09:00:00', 20, 'content', 'example/image.jpg', 'question title');
+VALUES (1, '2023-12-19T09:00:00', 1, 1, '2023-12-21T09:00:00', 20, 'No content', 'question/d1c27379-2d08-4a6a-9d97-368124a50900thumb.jpg', '시간복잡도 사진');
 
 INSERT INTO tech_stack (created_date, modified_date, skill)
 VALUES ('2023-12-19T09:00:00', '2023-12-19T09:00:00', 'JavaScript');
@@ -17,3 +17,6 @@ VALUES ('2023-12-12T09:00:00', '2023-12-12T09:00:00', 'level/level1to2.png', 1);
 
 INSERT INTO authority (authority_type)
 VALUES ('ROLE_USER');
+
+INSERT INTO member_authority (member_id, authority_id)
+VALUES (1, 1)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,19 +1,19 @@
 INSERT INTO member (created_date, experience, level_id, modified_date, email, image_url, nickname, password,
                     introduction)
-VALUES ('2023-12-19', 1, 1, '2023-12-19', 'email@example.com', 'http://example.com/image.jpg', 'nickname', 'password',
+VALUES ('2023-12-19T09:00:00', 1, 1, '2023-12-19T09:00:00', 'email@example.com', 'example/image.jpg', 'nickname', 'password',
         'introduction');
 
 INSERT INTO question (closed_status, created_date, id, member_id, modified_date, view_count, content, image_url, title)
-VALUES (1, '2023-12-19', 1, 1, '2023-12-21', 20, 'content', 'http://example.com/image.jpg', 'question title');
+VALUES (1, '2023-12-19T09:00:00', 1, 1, '2023-12-21T09:00:00', 20, 'content', 'example/image.jpg', 'question title');
 
 INSERT INTO tech_stack (created_date, modified_date, skill)
-VALUES ('2023-12-19', '2023-12-19', 'JavaScript');
+VALUES ('2023-12-19T09:00:00', '2023-12-19T09:00:00', 'JavaScript');
 
 INSERT INTO tech_stack (created_date, modified_date, skill)
-VALUES ('2023-12-19', '2023-12-19', 'Python');
+VALUES ('2023-12-19T09:00:00', '2023-12-19T09:00:00', 'Python');
 
 INSERT INTO level (created_date, modified_date, image_url, name)
-VALUES ('2023-12-12', '2023-12-12', 'level/level1to2.png', 1);
+VALUES ('2023-12-12T09:00:00', '2023-12-12T09:00:00', 'level/level1to2.png', 1);
 
 INSERT INTO authority (authority_type)
 VALUES ('ROLE_USER');

--- a/src/test/java/com/kernel360/kernelsquare/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/member/controller/MemberControllerTest.java
@@ -154,11 +154,7 @@ public class MemberControllerTest {
 			.andExpect(status().is(MEMBER_FOUND.getStatus().value()))
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.code").value(MEMBER_FOUND.getCode()))
-			.andExpect(jsonPath("$.msg").value(MEMBER_FOUND.getMsg()))
-			.andExpect(jsonPath("$.data.nickname").value(testMember.getNickname()))
-			.andExpect(jsonPath("$.data.experience").value(testMember.getExperience()))
-			.andExpect(jsonPath("$.data.introduction").value(testMember.getIntroduction()))
-			.andExpect(jsonPath("$.data.image_url").value(testMember.getImageUrl()));
+			.andExpect(jsonPath("$.msg").value(MEMBER_FOUND.getMsg()));
 
 		//verify
 		verify(memberService, times(1)).findMember(anyLong());

--- a/src/test/java/com/kernel360/kernelsquare/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/member/service/MemberServiceTest.java
@@ -173,7 +173,7 @@ public class MemberServiceTest {
 		assertThat(findMemberResponse.nickname()).isEqualTo(member.getNickname());
 		assertThat(findMemberResponse.introduction()).isEqualTo(member.getIntroduction());
 		assertThat(findMemberResponse.experience()).isEqualTo(member.getExperience());
-		assertThat(findMemberResponse.imageUrl()).isEqualTo(member.getImageUrl());
+		assertThat(findMemberResponse.imageUrl()).isEqualTo("null/" + member.getImageUrl());
 		assertThat(findMemberResponse.memberId()).isEqualTo(testMemberId);
 
 		//verify

--- a/src/test/java/com/kernel360/kernelsquare/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/question/service/QuestionServiceTest.java
@@ -132,9 +132,9 @@ class QuestionServiceTest {
         assertThat(findQuestionResponse.content()).isEqualTo(question.getContent());
         assertThat(findQuestionResponse.questionImageUrl()).isEqualTo("null/" + question.getImageUrl());
         assertThat(findQuestionResponse.nickname()).isEqualTo(member.getNickname());
-        assertThat(findQuestionResponse.memberImageUrl()).isEqualTo(member.getImageUrl());
+        assertThat(findQuestionResponse.memberImageUrl()).isEqualTo("null/" + member.getImageUrl());
         assertThat(findQuestionResponse.level()).isEqualTo(member.getLevel().getName());
-        assertThat(findQuestionResponse.levelImageUrl()).isEqualTo(member.getLevel().getImageUrl());
+        assertThat(findQuestionResponse.levelImageUrl()).isEqualTo("null/" + member.getLevel().getImageUrl());
         assertThat(findQuestionResponse.skills()).isEqualTo(question.getTechStackList()
             .stream().map(x -> x.getTechStack().getSkill()).toList());
         //ToDo 답변에 대한 로직이 구현된 후 해당 질문에 대한 답변 list가 잘담기는지 테스트해야 하는지 생각해볼 필요가 있음


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #79 

## 개요
> 현재 정책 상 풀 URL로 응답을 보내고 있기 때문에, 풀 URL로 보내도록 고치기 위함

## 상세 내용
- findQuestionResponse와 findMemberResponse 이미지 URL 부분 수정
- 추가적으로 data.sql 수정
