### PR TITLE
[refactor] AuthController 내부 서비스 분리 및 인증 관련 테스트 작성, Auth 관련 클래스 리팩토링

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,16 +12,18 @@ on:
   pull_request:
     branches: [ "main" ]
 
-
-
-
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
 
     steps:
       - uses: actions/checkout@v3

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/controller/AuthController.java
@@ -15,9 +15,12 @@ import com.kernel360.kernelsquare.domain.auth.dto.LoginResponse;
 import com.kernel360.kernelsquare.domain.auth.dto.SignUpRequest;
 import com.kernel360.kernelsquare.domain.auth.dto.SignUpResponse;
 import com.kernel360.kernelsquare.domain.auth.dto.TokenDto;
+import com.kernel360.kernelsquare.domain.auth.entity.RefreshToken;
 import com.kernel360.kernelsquare.domain.auth.service.AuthService;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.global.common_response.ApiResponse;
 import com.kernel360.kernelsquare.global.common_response.ResponseEntityFactory;
+import com.kernel360.kernelsquare.global.jwt.TokenProvider;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,10 +30,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 	private final AuthService authService;
+	private final TokenProvider tokenProvider;
 
 	@PostMapping("/auth/login")
 	public ResponseEntity<ApiResponse<LoginResponse>> login(final @RequestBody @Valid LoginRequest loginRequest) {
-		LoginResponse loginResponse = authService.login(loginRequest);
+		Member member = authService.login(loginRequest);
+		TokenDto tokenDto = tokenProvider.createToken(member, loginRequest);
+		LoginResponse loginResponse = LoginResponse.of(member, tokenDto);
 		return ResponseEntityFactory.toResponseEntity(LOGIN_SUCCESS, loginResponse);
 	}
 
@@ -42,7 +48,7 @@ public class AuthController {
 
 	@PostMapping("/auth/reissue")
 	public ResponseEntity<ApiResponse<TokenDto>> reissueAccessToken(final @RequestBody TokenDto requestTokenDto) {
-		TokenDto tokenDto = authService.reissueAccessToken(requestTokenDto);
+		TokenDto tokenDto = tokenProvider.reissueToken(requestTokenDto);
 		return ResponseEntityFactory.toResponseEntity(ACCESS_TOKEN_REISSUED, tokenDto);
 	}
 
@@ -62,7 +68,8 @@ public class AuthController {
 
 	@PostMapping("/auth/logout")
 	public ResponseEntity<ApiResponse> logout(final @RequestBody TokenDto tokenDto) {
-		authService.logout(tokenDto);
+		RefreshToken refreshToken = tokenProvider.toRefreshToken(tokenDto.refreshToken());
+		tokenProvider.removeRedisRefreshToken(refreshToken.getMemberId());
 		return ResponseEntityFactory.toResponseEntity(LOGOUT_SUCCESS);
 	}
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/controller/AuthController.java
@@ -14,8 +14,8 @@ import com.kernel360.kernelsquare.domain.auth.dto.LoginRequest;
 import com.kernel360.kernelsquare.domain.auth.dto.LoginResponse;
 import com.kernel360.kernelsquare.domain.auth.dto.SignUpRequest;
 import com.kernel360.kernelsquare.domain.auth.dto.SignUpResponse;
-import com.kernel360.kernelsquare.domain.auth.dto.TokenDto;
-import com.kernel360.kernelsquare.domain.auth.entity.RefreshToken;
+import com.kernel360.kernelsquare.domain.auth.dto.TokenRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.TokenResponse;
 import com.kernel360.kernelsquare.domain.auth.service.AuthService;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.global.common_response.ApiResponse;
@@ -35,8 +35,8 @@ public class AuthController {
 	@PostMapping("/auth/login")
 	public ResponseEntity<ApiResponse<LoginResponse>> login(final @RequestBody @Valid LoginRequest loginRequest) {
 		Member member = authService.login(loginRequest);
-		TokenDto tokenDto = tokenProvider.createToken(member, loginRequest);
-		LoginResponse loginResponse = LoginResponse.of(member, tokenDto);
+		TokenResponse tokenResponse = tokenProvider.createToken(member, loginRequest);
+		LoginResponse loginResponse = LoginResponse.of(member, tokenResponse);
 		return ResponseEntityFactory.toResponseEntity(LOGIN_SUCCESS, loginResponse);
 	}
 
@@ -47,9 +47,10 @@ public class AuthController {
 	}
 
 	@PostMapping("/auth/reissue")
-	public ResponseEntity<ApiResponse<TokenDto>> reissueAccessToken(final @RequestBody TokenDto requestTokenDto) {
-		TokenDto tokenDto = tokenProvider.reissueToken(requestTokenDto);
-		return ResponseEntityFactory.toResponseEntity(ACCESS_TOKEN_REISSUED, tokenDto);
+	public ResponseEntity<ApiResponse<TokenResponse>> reissueAccessToken(
+		final @RequestBody TokenRequest requestTokenRequest) {
+		TokenResponse tokenResponse = tokenProvider.reissueToken(requestTokenRequest);
+		return ResponseEntityFactory.toResponseEntity(ACCESS_TOKEN_REISSUED, tokenResponse);
 	}
 
 	@PostMapping("/auth/check/email")
@@ -67,9 +68,8 @@ public class AuthController {
 	}
 
 	@PostMapping("/auth/logout")
-	public ResponseEntity<ApiResponse> logout(final @RequestBody TokenDto tokenDto) {
-		RefreshToken refreshToken = tokenProvider.toRefreshToken(tokenDto.refreshToken());
-		tokenProvider.removeRedisRefreshToken(refreshToken.getMemberId());
+	public ResponseEntity<ApiResponse> logout(final @RequestBody TokenRequest tokenRequest) {
+		tokenProvider.logout(tokenRequest);
 		return ResponseEntityFactory.toResponseEntity(LOGOUT_SUCCESS);
 	}
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/CheckDuplicateEmailRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/CheckDuplicateEmailRequest.java
@@ -3,7 +3,9 @@ package com.kernel360.kernelsquare.domain.auth.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record CheckDuplicateEmailRequest(
 
 	@NotBlank(message = "이메일은 필수 입력 항목입니다.")

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/CheckDuplicateNicknameRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/CheckDuplicateNicknameRequest.java
@@ -2,7 +2,9 @@ package com.kernel360.kernelsquare.domain.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record CheckDuplicateNicknameRequest(
 	@NotBlank(message = "닉네임은 필수 입력 항목입니다.")
 	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요")

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginRequest.java
@@ -3,7 +3,9 @@ package com.kernel360.kernelsquare.domain.auth.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record LoginRequest(
 	@NotBlank(message = "이메일은 필수 입력 항목입니다.")
 	@Email(message = "이메일 형식을 확인해 주세요")

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
@@ -16,10 +16,11 @@ public record LoginResponse(
 	String imageUrl,
 	Long level,
 	List<String> roles,
-	TokenDto tokenDto
+	TokenResponse tokenDto
+
 ) {
 
-	public static LoginResponse of(Member member, TokenDto tokenDto) {
+	public static LoginResponse of(Member member, TokenResponse tokenResponse) {
 		List<String> roles = member.getAuthorities().stream()
 			.map(MemberAuthority::getAuthority)
 			.map(String::valueOf)
@@ -33,7 +34,7 @@ public record LoginResponse(
 			.imageUrl(member.getImageUrl())
 			.level(member.getLevel().getName())
 			.roles(roles)
-			.tokenDto(tokenDto)
+			.tokenDto(tokenResponse)
 			.build();
 	}
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
@@ -1,11 +1,9 @@
 package com.kernel360.kernelsquare.domain.auth.dto;
 
-import java.util.Collection;
 import java.util.List;
 
-import org.springframework.security.core.GrantedAuthority;
-
 import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.member_authority.entity.MemberAuthority;
 
 import lombok.Builder;
 
@@ -21,9 +19,9 @@ public record LoginResponse(
 	TokenDto tokenDto
 ) {
 
-	public static LoginResponse of(Member member, Collection<? extends GrantedAuthority> authorities,
-		TokenDto tokenDto) {
-		List<String> roles = authorities.stream()
+	public static LoginResponse of(Member member, TokenDto tokenDto) {
+		List<String> roles = member.getAuthorities().stream()
+			.map(MemberAuthority::getAuthority)
 			.map(String::valueOf)
 			.toList();
 

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/SignUpRequest.java
@@ -6,7 +6,9 @@ import com.kernel360.kernelsquare.domain.member.entity.Member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record SignUpRequest(
 	@NotBlank(message = "이메일은 필수 입력 항목입니다.")
 	@Email(message = "이메일 형식을 확인해 주세요")

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/TokenRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/TokenRequest.java
@@ -3,15 +3,15 @@ package com.kernel360.kernelsquare.domain.auth.dto;
 import lombok.Builder;
 
 @Builder
-public record TokenDto(
+public record TokenRequest(
 	String accessToken,
 	String refreshToken) {
 
-	public static TokenDto of(
+	public static TokenRequest of(
 		String accessToken,
 		String refreshToken
 	) {
-		return TokenDto
+		return TokenRequest
 			.builder()
 			.accessToken(accessToken)
 			.refreshToken(refreshToken)

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,20 @@
+package com.kernel360.kernelsquare.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponse(
+	String accessToken,
+	String refreshToken) {
+
+	public static TokenResponse of(
+		String accessToken,
+		String refreshToken
+	) {
+		return TokenResponse
+			.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+	}
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/service/AuthService.java
@@ -2,19 +2,13 @@ package com.kernel360.kernelsquare.domain.auth.service;
 
 import java.util.List;
 
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kernel360.kernelsquare.domain.auth.dto.LoginRequest;
-import com.kernel360.kernelsquare.domain.auth.dto.LoginResponse;
 import com.kernel360.kernelsquare.domain.auth.dto.SignUpRequest;
 import com.kernel360.kernelsquare.domain.auth.dto.SignUpResponse;
-import com.kernel360.kernelsquare.domain.auth.dto.TokenDto;
-import com.kernel360.kernelsquare.domain.auth.entity.RefreshToken;
 import com.kernel360.kernelsquare.domain.authority.entity.Authority;
 import com.kernel360.kernelsquare.domain.authority.repository.AuthorityRepository;
 import com.kernel360.kernelsquare.domain.level.entity.Level;
@@ -28,7 +22,6 @@ import com.kernel360.kernelsquare.global.common_response.error.code.AuthorityErr
 import com.kernel360.kernelsquare.global.common_response.error.code.LevelErrorCode;
 import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
 import com.kernel360.kernelsquare.global.domain.AuthorityType;
-import com.kernel360.kernelsquare.global.jwt.TokenProvider;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,25 +29,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthService {
 	private final PasswordEncoder passwordEncoder;
-	private final TokenProvider tokenProvider;
 	private final MemberRepository memberRepository;
 	private final MemberAuthorityRepository memberAuthorityRepository;
 	private final AuthorityRepository authorityRepository;
 	private final LevelRepository levelRepository;
-	private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
 	@Transactional(readOnly = true)
-	public LoginResponse login(final LoginRequest loginRequest) {
+	public Member login(final LoginRequest loginRequest) {
 		Member findMember = memberRepository.findByEmail(loginRequest.email())
 			.orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_ACCOUNT));
-		validateLogin(loginRequest, findMember);
-		UsernamePasswordAuthenticationToken authenticationToken =
-			new UsernamePasswordAuthenticationToken(findMember.getId(), loginRequest.password());
-		Authentication authentication = authenticationManagerBuilder.getObject()
-			.authenticate(authenticationToken);
-		TokenDto tokenDto = tokenProvider.createToken(authentication);
-
-		return LoginResponse.of(findMember, authentication.getAuthorities(), tokenDto);
+		if (!passwordEncoder.matches(loginRequest.password(), findMember.getPassword())) {
+			throw new BusinessException(AuthErrorCode.INVALID_PASSWORD);
+		}
+		return findMember;
 	}
 
 	@Transactional
@@ -73,22 +60,6 @@ public class AuthService {
 		savedMember.initAuthorities(authorities);
 
 		return SignUpResponse.of(savedMember);
-	}
-
-	private void validateLogin(LoginRequest loginRequest, Member member) {
-		if (!passwordEncoder.matches(loginRequest.password(), member.getPassword())) {
-			throw new BusinessException(AuthErrorCode.INVALID_PASSWORD);
-		}
-	}
-
-	public void logout(final TokenDto tokenDto) {
-		RefreshToken refreshToken = tokenProvider.toRefreshToken(tokenDto.refreshToken());
-		Long memberId = refreshToken.getMemberId();
-		tokenProvider.removeRedisRefreshToken(memberId);
-	}
-
-	public TokenDto reissueAccessToken(final TokenDto requestTokenDto) {
-		return tokenProvider.reissueToken(requestTokenDto);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/service/AuthService.java
@@ -46,7 +46,7 @@ public class AuthService {
 
 	@Transactional
 	public SignUpResponse signUp(final SignUpRequest signUpRequest) {
-		Level level = levelRepository.findLevelByName(1L)
+		Level level = levelRepository.findByName(1L)
 			.orElseThrow(() -> new BusinessException(LevelErrorCode.LEVEL_NOT_FOUND));
 		String encodedPassword = passwordEncoder.encode(signUpRequest.password());
 		Member savedMember = memberRepository.save(SignUpRequest.toEntity(signUpRequest, encodedPassword, level));

--- a/src/main/java/com/kernel360/kernelsquare/domain/authority/entity/Authority.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/authority/entity/Authority.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,4 +27,10 @@ public class Authority {
 	@Enumerated(value = EnumType.STRING)
 	@Column(nullable = false, name = "authority_type", columnDefinition = "varchar(20)")
 	private AuthorityType authorityType;
+
+	@Builder
+	public Authority(Long id, AuthorityType authorityType) {
+		this.id = id;
+		this.authorityType = authorityType;
+	}
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/level/repository/LevelRepository.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/level/repository/LevelRepository.java
@@ -1,14 +1,15 @@
 package com.kernel360.kernelsquare.domain.level.repository;
 
-import com.kernel360.kernelsquare.domain.level.entity.Level;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import com.kernel360.kernelsquare.domain.level.entity.Level;
 
 public interface LevelRepository extends JpaRepository<Level, Long> {
-	Optional<Level> findLevelByName(Long name);
+	Optional<Level> findByName(Long name);
 
 	@Query("SELECT l FROM level l WHERE l.name = :levelName AND l.id != :levelId")
 	Optional<Level> findByNameAndIdNot(@Param("levelName") Long levelName, @Param("levelId") Long levelId);

--- a/src/main/java/com/kernel360/kernelsquare/global/jwt/TokenProvider.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/jwt/TokenProvider.java
@@ -2,11 +2,13 @@ package com.kernel360.kernelsquare.global.jwt;
 
 import static com.kernel360.kernelsquare.global.common_response.error.code.TokenErrorCode.*;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -28,7 +30,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.kernel360.kernelsquare.domain.auth.dto.LoginRequest;
-import com.kernel360.kernelsquare.domain.auth.dto.TokenDto;
+import com.kernel360.kernelsquare.domain.auth.dto.TokenRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.TokenResponse;
 import com.kernel360.kernelsquare.domain.auth.entity.RefreshToken;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
@@ -41,6 +44,7 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +75,13 @@ public class TokenProvider implements InitializingBean {
 		this.key = Keys.hmacShaKeyFor(keyBytes);
 	}
 
-	public TokenDto createToken(Member member, LoginRequest loginRequest) {
+	public void logout(TokenRequest tokenRequest) {
+		RefreshToken refreshToken = toRefreshToken(
+			new String(Base64.getDecoder().decode(tokenRequest.refreshToken()), StandardCharsets.UTF_8));
+		redisTemplate.opsForValue().getOperations().delete(refreshToken.getMemberId());
+	}
+
+	public TokenResponse createToken(Member member, LoginRequest loginRequest) {
 		UsernamePasswordAuthenticationToken authenticationToken =
 			new UsernamePasswordAuthenticationToken(member.getId(), loginRequest.password());
 		Authentication authentication = authenticationManagerBuilder.getObject()
@@ -79,12 +89,12 @@ public class TokenProvider implements InitializingBean {
 		String authorities = authentication.getAuthorities().stream()
 			.map(GrantedAuthority::getAuthority)
 			.collect(Collectors.joining(","));
-		return TokenDto.of(
+		return TokenResponse.of(
 			createAccessToken(authentication.getName(), authorities),
 			createRefreshToken(authentication.getName()));
 	}
 
-	public String createAccessToken(String sub, String roles) {
+	private String createAccessToken(String sub, String roles) {
 		LocalDateTime localDateTime = LocalDateTime.now()
 			.plusSeconds(accessTokenValidityInSeconds);
 		Instant instant = localDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -98,7 +108,7 @@ public class TokenProvider implements InitializingBean {
 			.compact();
 	}
 
-	public String createRefreshToken(String sub) {
+	private String createRefreshToken(String sub) {
 		LocalDateTime expirationDate = LocalDateTime.now()
 			.plusSeconds(refreshTokenValidityInSeconds);
 
@@ -113,7 +123,7 @@ public class TokenProvider implements InitializingBean {
 
 		redisTemplate.opsForValue().set(refreshToken.getMemberId(), refreshToken);
 
-		return toJsonString(refreshToken);
+		return Encoders.BASE64.encode(toJsonString(refreshToken).getBytes());
 	}
 
 	private String toJsonString(RefreshToken refreshToken) {
@@ -152,7 +162,7 @@ public class TokenProvider implements InitializingBean {
 		return new UsernamePasswordAuthenticationToken(principal, token, authorities);
 	}
 
-	public Claims parseClaims(String token) {
+	private Claims parseClaims(String token) {
 		try {
 			Claims claims = Jwts.parserBuilder()
 				.setSigningKey(key)
@@ -182,14 +192,14 @@ public class TokenProvider implements InitializingBean {
 	}
 
 	/** Refresh Token 재발급 **/
-	public TokenDto reissueToken(TokenDto tokenDto) {
-		Claims claims = parseClaims(tokenDto.accessToken());
-		String findIdByAccessToken = parseClaims(tokenDto.accessToken()).getSubject();
+	public TokenResponse reissueToken(TokenRequest tokenRequest) {
+		Claims claims = parseClaims(tokenRequest.accessToken());
+		String findIdByAccessToken = parseClaims(tokenRequest.accessToken()).getSubject();
 		RefreshToken refreshToken = redisTemplate.opsForValue().get(Long.parseLong(findIdByAccessToken));
 
 		validateReissueToken(refreshToken, findIdByAccessToken);
 
-		return TokenDto.builder()
+		return TokenResponse.builder()
 			.accessToken(createAccessToken(String.valueOf(refreshToken.getMemberId()), claims.get("auth").toString()))
 			.refreshToken(createRefreshToken(String.valueOf(refreshToken.getMemberId())))
 			.build();
@@ -198,16 +208,12 @@ public class TokenProvider implements InitializingBean {
 	/** Reissued Token 유효성 검증을 수행 **/
 	private void validateReissueToken(RefreshToken refreshToken, String accessTokenId) {
 		if (!refreshToken.getExpirationDate().isAfter(LocalDateTime.now())) {
-			removeRedisRefreshToken(refreshToken.getMemberId());
+			redisTemplate.opsForValue().getOperations().delete(refreshToken.getMemberId());
 			throw new BusinessException(EXPIRED_LOGIN_INFO);
 		}
-		if (!accessTokenId.equals(refreshToken.getMemberId())) {
+		if (!accessTokenId.equals(String.valueOf(refreshToken.getMemberId()))) {
 			throw new BusinessException(INVALID_TOKEN);
 		}
-	}
-
-	public void removeRedisRefreshToken(Long id) {
-		redisTemplate.opsForValue().getOperations().delete(id);
 	}
 }
 

--- a/src/test/java/com/kernel360/kernelsquare/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,319 @@
+package com.kernel360.kernelsquare.domain.auth.controller;
+
+import static com.kernel360.kernelsquare.global.common_response.response.code.AuthResponseCode.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kernel360.kernelsquare.domain.auth.dto.CheckDuplicateEmailRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.CheckDuplicateNicknameRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.LoginRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.SignUpRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.SignUpResponse;
+import com.kernel360.kernelsquare.domain.auth.dto.TokenRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.TokenResponse;
+import com.kernel360.kernelsquare.domain.auth.service.AuthService;
+import com.kernel360.kernelsquare.domain.authority.entity.Authority;
+import com.kernel360.kernelsquare.domain.level.entity.Level;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.member_authority.entity.MemberAuthority;
+import com.kernel360.kernelsquare.global.domain.AuthorityType;
+import com.kernel360.kernelsquare.global.jwt.TokenProvider;
+
+@DisplayName("인증 컨트롤러 테스트")
+@WebMvcTest(AuthController.class)
+public class AuthControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private AuthService authService;
+
+	@MockBean
+	private TokenProvider tokenProvider;
+
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	@WithMockUser(roles = "{}")
+	@DisplayName("회원 로그인 성공시, 200 OK와 정상 응답을 반환한다.")
+	void testLogin() throws Exception {
+		//given
+		Level testLevel = Level.builder()
+			.id(1L)
+			.name(1L)
+			.imageUrl("s3:dq1234512")
+			.build();
+
+		Authority authority = Authority.builder()
+			.id(1L)
+			.authorityType(AuthorityType.ROLE_USER)
+			.build();
+
+		Member member = Member
+			.builder()
+			.id(1L)
+			.nickname("hongjugwang")
+			.email("jugwang@naver.com")
+			.password("hashedPassword")
+			.experience(10000L)
+			.introduction("hi, i'm hongjugwang.")
+			.imageUrl("s3:qwe12fasdawczx")
+			.level(testLevel)
+			.build();
+
+		MemberAuthority memberAuthority = MemberAuthority
+			.builder()
+			.member(member)
+			.authority(authority)
+			.build();
+
+		List<MemberAuthority> memberAuthorityList = List.of(memberAuthority);
+		member.initAuthorities(memberAuthorityList);
+
+		LoginRequest loginRequest = LoginRequest.builder()
+			.email("jugwang@naver.com")
+			.password("hashedPassword")
+			.build();
+
+		TokenResponse tokenResponse = TokenResponse.builder()
+			.accessToken("dawdawdawd")
+			.refreshToken("ghsefaefaseg")
+			.build();
+
+		doReturn(member)
+			.when(authService)
+			.login(any(LoginRequest.class));
+
+		doReturn(tokenResponse)
+			.when(tokenProvider)
+			.createToken(any(Member.class), any(LoginRequest.class));
+
+		String jsonRequest = objectMapper.writeValueAsString(loginRequest);
+
+		//when & then
+		mockMvc.perform(post("/api/v1/auth/login")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.characterEncoding("UTF-8")
+				.content(jsonRequest))
+			.andExpect(status().is(LOGIN_SUCCESS.getStatus().value()))
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.code").value(LOGIN_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.msg").value(LOGIN_SUCCESS.getMsg()));
+
+		//verify
+		verify(authService, times(1)).login(any(LoginRequest.class));
+		verify(authService, only()).login(any(LoginRequest.class));
+		verify(tokenProvider, times(1)).createToken(any(Member.class), any(LoginRequest.class));
+		verify(tokenProvider, only()).createToken(any(Member.class), any(LoginRequest.class));
+	}
+
+	@Test
+	@WithMockUser(roles = "{}")
+	@DisplayName("회원 가입에 성공하면, 200 OK와 정상 응답을 반환한다.")
+	void testSignUp() throws Exception {
+		//given
+		SignUpRequest signUpRequest = SignUpRequest
+			.builder()
+			.nickname("woww")
+			.email("jugwang@naver.com")
+			.password("hashedPassword")
+			.build();
+
+		Member member = Member
+			.builder()
+			.id(1L)
+			.nickname("woww")
+			.email("jugwang@naver.com")
+			.password("hashedPassword")
+			.experience(10000L)
+			.introduction("hi, i'm hongjugwang.")
+			.imageUrl("s3:qwe12fasdawczx")
+			.build();
+
+		SignUpResponse signUpResponse = SignUpResponse
+			.of(member);
+
+		String jsonRequest = objectMapper.writeValueAsString(signUpRequest);
+
+		doReturn(signUpResponse)
+			.when(authService)
+			.signUp(any(SignUpRequest.class));
+
+		//when & then
+		mockMvc.perform(post("/api/v1/auth/signup")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.characterEncoding("UTF-8")
+				.content(jsonRequest))
+			.andExpect(status().is(SIGN_UP_SUCCESS.getStatus().value()))
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.code").value(SIGN_UP_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.msg").value(SIGN_UP_SUCCESS.getMsg()));
+
+		//verify
+		verify(authService, times(1)).signUp(any(SignUpRequest.class));
+		verify(authService, only()).signUp(any(SignUpRequest.class));
+	}
+
+	@Test
+	@WithMockUser
+	@DisplayName("액세스 토큰 재발급 성공 시, 200 OK와 정상 응답을 반환한다.")
+	void testReissueAccessToken() throws Exception {
+		//given
+		TokenRequest tokenRequest = TokenRequest
+			.builder()
+			.accessToken("dasdas")
+			.refreshToken("gawgawgawgawg")
+			.build();
+
+		TokenResponse tokenResponse = TokenResponse.builder()
+			.accessToken("dawdawdawd")
+			.refreshToken("ghsefaefaseg")
+			.build();
+
+		String jsonRequest = objectMapper.writeValueAsString(tokenRequest);
+
+		doReturn(tokenResponse)
+			.when(tokenProvider)
+			.reissueToken(any(TokenRequest.class));
+
+		//when & then
+		mockMvc.perform(post("/api/v1/auth/reissue")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.characterEncoding("UTF-8")
+				.content(jsonRequest))
+			.andExpect(status().is(ACCESS_TOKEN_REISSUED.getStatus().value()))
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.code").value(ACCESS_TOKEN_REISSUED.getCode()))
+			.andExpect(jsonPath("$.msg").value(ACCESS_TOKEN_REISSUED.getMsg()));
+
+		//verify
+		verify(tokenProvider, times(1)).reissueToken(any(TokenRequest.class));
+	}
+
+	@Test
+	@WithMockUser(roles = "{}")
+	@DisplayName("이메일 중복이 아니면, 200 OK와 정상 응답을 보낸다.")
+	void testIsEmailUnique() throws Exception {
+		//given
+		CheckDuplicateEmailRequest checkDuplicateEmailRequest
+			= CheckDuplicateEmailRequest
+			.builder()
+			.email("hongju@naver.com")
+			.build();
+
+		String jsonRequest = objectMapper.writeValueAsString(checkDuplicateEmailRequest);
+
+		doNothing()
+			.when(authService)
+			.isEmailUnique(anyString());
+
+		//when & then
+		mockMvc.perform(post("/api/v1/auth/check/email")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.characterEncoding("UTF-8")
+				.content(jsonRequest))
+			.andExpect(status().is(EMAIL_UNIQUE_VALIDATED.getStatus().value()))
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.code").value(EMAIL_UNIQUE_VALIDATED.getCode()))
+			.andExpect(jsonPath("$.msg").value(EMAIL_UNIQUE_VALIDATED.getMsg()));
+
+		//verify
+		verify(authService, times(1)).isEmailUnique(anyString());
+		verify(authService, only()).isEmailUnique(anyString());
+	}
+
+	@Test
+	@WithMockUser(roles = "{}")
+	@DisplayName("닉네임이 중복이 아니면, 200 OK와 정상 응답을 반환한다.")
+	void testNicknameUnique() throws Exception {
+		//given
+		CheckDuplicateNicknameRequest checkDuplicateNicknameRequest =
+			CheckDuplicateNicknameRequest
+				.builder()
+				.nickname("야야야야")
+				.build();
+
+		String jsonRequest = objectMapper.writeValueAsString(checkDuplicateNicknameRequest);
+
+		doNothing()
+			.when(authService)
+			.isNicknameUnique(anyString());
+
+		//when & then
+		mockMvc.perform(post("/api/v1/auth/check/nickname")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.characterEncoding("UTF-8")
+				.content(jsonRequest))
+			.andExpect(status().is(NICKNAME_UNIQUE_VALIDATED.getStatus().value()))
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.code").value(NICKNAME_UNIQUE_VALIDATED.getCode()))
+			.andExpect(jsonPath("$.msg").value(NICKNAME_UNIQUE_VALIDATED.getMsg()));
+
+		//verify
+		verify(authService, times(1)).isNicknameUnique(anyString());
+		verify(authService, only()).isNicknameUnique(anyString());
+	}
+
+	@Test
+	@WithMockUser
+	@DisplayName("로그아웃 성공 시, 200 OK와 정상 응답을 보낸다")
+	void testLogOut() throws Exception {
+		//given
+		TokenRequest tokenRequest = TokenRequest
+			.builder()
+			.accessToken("dasdas")
+			.refreshToken(
+				"IntcIlJlZnJlc2hUb2tlbi5jbGFzc1wiOlwiY29tLmtlcm5lbDM2MC5rZXJuZWxzcXVhcmUuZG9tYWluLmF1dGguZW50aXR5LlJlZnJlc2hUb2tlblwiLFwibWVtYmVySWRcIjoxLFwicmVmcmVzaFRva2VuXCI6XCJkM2Y4M2FjMzAxZTQ0N2M2OTVkMzcyNDAyNDdhYzFiZFwiLFwiY3JlYXRlZERhdGVcIjpbMjAyNCwxLDExLDksNCw1OCw1NzM2OTkwMDBdLFwiZXhwaXJhdGlvbkRhdGVcIjpbMjAyNCwxLDExLDksNCw1OCw1NzM1NTMwMDBdfSI=")
+			.build();
+
+		String jsonRequest = objectMapper.writeValueAsString(tokenRequest);
+
+		System.out.println("tokenRequest.accessToken() = " + tokenRequest.accessToken());
+		System.out.println("tokenRequest.refreshToken() = " + tokenRequest.refreshToken());
+		System.out.println("jsonRequest = " + jsonRequest);
+
+		doNothing()
+			.when(tokenProvider)
+			.logout(any(TokenRequest.class));
+
+		//when & then
+		mockMvc.perform(post("/api/v1/auth/logout")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.characterEncoding("UTF-8")
+				.content(jsonRequest))
+			.andExpect(status().is(LOGOUT_SUCCESS.getStatus().value()))
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.code").value(LOGOUT_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.msg").value(LOGOUT_SUCCESS.getMsg()));
+
+		//verify
+		verify(tokenProvider, times(1)).logout(any(TokenRequest.class));
+		verify(tokenProvider, only()).logout(any(TokenRequest.class));
+	}
+}

--- a/src/test/java/com/kernel360/kernelsquare/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,121 @@
+package com.kernel360.kernelsquare.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.kernel360.kernelsquare.domain.auth.dto.LoginRequest;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
+import com.kernel360.kernelsquare.global.common_response.error.code.AuthErrorCode;
+import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
+
+@DisplayName("인증 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+	@InjectMocks
+	private AuthService authService;
+	@Mock
+	private MemberRepository memberRepository;
+	@Spy
+	private PasswordEncoder passwordEncoder;
+
+	@Test
+	@DisplayName("로그인 테스트")
+	void testLogIn() throws Exception {
+		//given
+		String testEmail = "inthemeantime@name.com";
+		String testPassword = "letmego";
+
+		LoginRequest loginRequest = LoginRequest.builder()
+			.email(testEmail)
+			.password(testPassword)
+			.build();
+
+		Member member = Member.builder()
+			.id(1L)
+			.email(testEmail)
+			.introduction("idontwannnaknow")
+			.nickname("notnow")
+			.password(passwordEncoder.encode(testPassword))
+			.experience(1000L)
+			.imageUrl("s3:myface")
+			.build();
+
+		Optional<Member> optionalMember = Optional.of(member);
+
+		doReturn(optionalMember)
+			.when(memberRepository)
+			.findByEmail(anyString());
+		
+		System.out.println("passwordEncoder = " + passwordEncoder.encode(testPassword));
+
+		//when
+		Member loginMember = authService.login(loginRequest);
+
+		//then
+		assertThat(loginMember.getEmail()).isEqualTo(testEmail);
+
+		assertThat(passwordEncoder.matches(loginRequest.password(), loginMember.getPassword())).isTrue();
+
+		//verify
+		verify(memberRepository, only()).existsByEmail(anyString());
+		verify(memberRepository, atMostOnce()).existsByEmail(anyString());
+	}
+
+	@Test
+	@DisplayName("이메일 중복 확인 테스트")
+	void testIsEmailUnique() throws Exception {
+		//given
+		String email = "idont@naver.com";
+
+		doReturn(true).when(memberRepository).existsByEmail(anyString());
+
+		//when
+
+		//then
+		assertThatThrownBy(() ->
+			authService.isEmailUnique(email))
+			.isExactlyInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.ALREADY_SAVED_EMAIL);
+
+		//verify
+		verify(memberRepository, only()).existsByEmail(anyString());
+		verify(memberRepository, atMostOnce()).existsByEmail(anyString());
+	}
+
+	@Test
+	@DisplayName("닉네임 중복 확인 테스트")
+	void testIsNicknameUnique() throws Exception {
+		//given
+		String nickname = "hong";
+
+		doReturn(true)
+			.when(memberRepository)
+			.existsByNickname(anyString());
+
+		//when
+
+		//then
+		assertThatThrownBy(() ->
+			authService.isNicknameUnique(nickname))
+			.isExactlyInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.ALREADY_SAVED_NICKNAME);
+
+		//verify
+		verify(memberRepository, only()).existsByNickname(anyString());
+		verify(memberRepository, atMostOnce()).existsByNickname(anyString());
+	}
+}

--- a/src/test/java/com/kernel360/kernelsquare/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/auth/service/AuthServiceTest.java
@@ -10,15 +10,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.kernel360.kernelsquare.domain.auth.dto.LoginRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.SignUpRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.SignUpResponse;
+import com.kernel360.kernelsquare.domain.authority.entity.Authority;
+import com.kernel360.kernelsquare.domain.authority.repository.AuthorityRepository;
+import com.kernel360.kernelsquare.domain.level.entity.Level;
+import com.kernel360.kernelsquare.domain.level.repository.LevelRepository;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
+import com.kernel360.kernelsquare.domain.member_authority.entity.MemberAuthority;
+import com.kernel360.kernelsquare.domain.member_authority.repository.MemberAuthorityRepository;
 import com.kernel360.kernelsquare.global.common_response.error.code.AuthErrorCode;
 import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
+import com.kernel360.kernelsquare.global.domain.AuthorityType;
 
 @DisplayName("인증 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -27,8 +38,14 @@ public class AuthServiceTest {
 	private AuthService authService;
 	@Mock
 	private MemberRepository memberRepository;
+	@Mock
+	private LevelRepository levelRepository;
+	@Mock
+	private AuthorityRepository authorityRepository;
+	@Mock
+	private MemberAuthorityRepository memberAuthorityRepository;
 	@Spy
-	private PasswordEncoder passwordEncoder;
+	private PasswordEncoder passwordEncoder = Mockito.spy(BCryptPasswordEncoder.class);
 
 	@Test
 	@DisplayName("로그인 테스트")
@@ -57,20 +74,90 @@ public class AuthServiceTest {
 		doReturn(optionalMember)
 			.when(memberRepository)
 			.findByEmail(anyString());
-		
-		System.out.println("passwordEncoder = " + passwordEncoder.encode(testPassword));
 
 		//when
 		Member loginMember = authService.login(loginRequest);
 
 		//then
 		assertThat(loginMember.getEmail()).isEqualTo(testEmail);
-
 		assertThat(passwordEncoder.matches(loginRequest.password(), loginMember.getPassword())).isTrue();
 
 		//verify
-		verify(memberRepository, only()).existsByEmail(anyString());
-		verify(memberRepository, atMostOnce()).existsByEmail(anyString());
+		verify(memberRepository, only()).findByEmail(anyString());
+		verify(memberRepository, times(1)).findByEmail(anyString());
+		verify(passwordEncoder, times(2)).matches(anyString(), anyString());
+	}
+
+	@Test
+	@DisplayName("회원 가입 테스트")
+	void testSignUp() throws Exception {
+		//given
+		String password = "hashed_password";
+		String encodedPassword = passwordEncoder.encode(password);
+
+		SignUpRequest signUpRequest = SignUpRequest.builder()
+			.nickname("순두부")
+			.email("whattobe@naver.com")
+			.password("hashed_password")
+			.build();
+
+		Level level = Level.builder()
+			.id(1L)
+			.name(1L)
+			.imageUrl("s3:whatever")
+			.build();
+
+		Optional<Level> optionalLevel = Optional.of(level);
+
+		Member member = Member.builder()
+			.id(1L)
+			.email(signUpRequest.email())
+			.nickname(signUpRequest.nickname())
+			.password(encodedPassword)
+			.level(level)
+			.build();
+
+		Authority authority = Authority.builder()
+			.id(1L)
+			.authorityType(AuthorityType.ROLE_USER)
+			.build();
+
+		Optional<Authority> optionalAuthority = Optional.of(authority);
+
+		MemberAuthority memberAuthority = MemberAuthority.builder()
+			.member(member)
+			.authority(authority)
+			.build();
+
+		doReturn(optionalLevel).
+			when(levelRepository)
+			.findByName(anyLong());
+
+		doReturn(member)
+			.when(memberRepository)
+			.save(any(Member.class));
+
+		doReturn(optionalAuthority)
+			.when(authorityRepository)
+			.findAuthorityByAuthorityType(any(AuthorityType.class));
+
+		doReturn(memberAuthority)
+			.when(memberAuthorityRepository)
+			.save(any(MemberAuthority.class));
+
+		//when
+		SignUpResponse signUpResponse = authService.signUp(signUpRequest);
+
+		//then
+		assertThat(signUpResponse.memberId()).isNotNull();
+
+		//verify
+		verify(levelRepository, only()).findByName(anyLong());
+		verify(levelRepository, times(1)).findByName(anyLong());
+
+		verify(passwordEncoder, times(2)).encode(anyString());
+
+		verify(memberRepository, times(1)).save(any(Member.class));
 	}
 
 	@Test
@@ -92,7 +179,7 @@ public class AuthServiceTest {
 
 		//verify
 		verify(memberRepository, only()).existsByEmail(anyString());
-		verify(memberRepository, atMostOnce()).existsByEmail(anyString());
+		verify(memberRepository, times(1)).existsByEmail(anyString());
 	}
 
 	@Test
@@ -116,6 +203,6 @@ public class AuthServiceTest {
 
 		//verify
 		verify(memberRepository, only()).existsByNickname(anyString());
-		verify(memberRepository, atMostOnce()).existsByNickname(anyString());
+		verify(memberRepository, times(1)).existsByNickname(anyString());
 	}
 }

--- a/src/test/java/com/kernel360/kernelsquare/domain/auth/service/MemberDetailServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/auth/service/MemberDetailServiceTest.java
@@ -87,6 +87,6 @@ public class MemberDetailServiceTest {
 
 		//verify
 		verify(memberRepository, only()).findById(anyLong());
-		verify(memberRepository, atMostOnce()).findById(anyLong());
+		verify(memberRepository, times(1)).findById(anyLong());
 	}
 }

--- a/src/test/java/com/kernel360/kernelsquare/domain/auth/service/MemberDetailServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/auth/service/MemberDetailServiceTest.java
@@ -1,0 +1,92 @@
+package com.kernel360.kernelsquare.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.kernel360.kernelsquare.domain.authority.entity.Authority;
+import com.kernel360.kernelsquare.domain.level.entity.Level;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
+import com.kernel360.kernelsquare.domain.member_authority.entity.MemberAuthority;
+import com.kernel360.kernelsquare.global.domain.AuthorityType;
+
+@DisplayName("회원 디테일 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+public class MemberDetailServiceTest {
+	@InjectMocks
+	private MemberDetailService memberDetailService;
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("회원 권한 주입 테스트")
+	void testLoadByUserName() throws Exception {
+		//given
+		Level level = Level.builder()
+			.name(1L)
+			.imageUrl("s3:somewhere")
+			.build();
+
+		Authority authority = Authority.builder()
+			.id(1L)
+			.authorityType(AuthorityType.ROLE_USER)
+			.build();
+
+		Member member = Member.builder()
+			.id(1L)
+			.email("inthemeantime@name.com")
+			.introduction("idontwannnaknow")
+			.nickname("notnow")
+			.level(level)
+			.password("whysoserious")
+			.experience(1000L)
+			.imageUrl("s3:myface")
+			.build();
+
+		MemberAuthority memberAuthority = MemberAuthority.builder()
+			.member(member)
+			.authority(authority)
+			.build();
+
+		List<MemberAuthority> memberAuthorities = List.of(memberAuthority);
+
+		member.initAuthorities(memberAuthorities);
+
+		Optional<Member> optionalMember = Optional.of(member);
+
+		Set<SimpleGrantedAuthority> authorities = member.getAuthorities().stream()
+			.map(MemberAuthority::getAuthority)
+			.map(auth -> new SimpleGrantedAuthority(auth.getAuthorityType().getDescription()))
+			.collect(Collectors.toUnmodifiableSet());
+
+		doReturn(optionalMember)
+			.when(memberRepository)
+			.findById(anyLong());
+
+		//when
+		UserDetails userDetails = memberDetailService.loadUserByUsername(String.valueOf(member.getId()));
+
+		//then
+		assertThat(userDetails.getUsername()).isEqualTo(String.valueOf(member.getId()));
+		assertThat(userDetails.getPassword()).isEqualTo(member.getPassword());
+		assertThat(userDetails.getAuthorities()).isEqualTo(authorities);
+
+		//verify
+		verify(memberRepository, only()).findById(anyLong());
+		verify(memberRepository, atMostOnce()).findById(anyLong());
+	}
+}

--- a/src/test/java/com/kernel360/kernelsquare/domain/level/repository/LevelRepositoryTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/level/repository/LevelRepositoryTest.java
@@ -1,25 +1,26 @@
 package com.kernel360.kernelsquare.domain.level.repository;
 
-import com.kernel360.kernelsquare.domain.level.entity.Level;
-import com.kernel360.kernelsquare.global.common_response.error.code.LevelErrorCode;
-import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
-import com.kernel360.kernelsquare.global.config.JpaAuditingConfig;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.kernel360.kernelsquare.domain.level.entity.Level;
+import com.kernel360.kernelsquare.global.common_response.error.code.LevelErrorCode;
+import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
+import com.kernel360.kernelsquare.global.config.JpaAuditingConfig;
 
 @DisplayName("레벨 레포지토리 통합 테스트")
 @DataJpaTest
 @Import(JpaAuditingConfig.class)
 class LevelRepositoryTest {
-    @Autowired
-    private LevelRepository levelRepository;
+	@Autowired
+	private LevelRepository levelRepository;
 
     @Test
     @DisplayName("레벨 findLevelByName 정상 작동 테스트")
@@ -34,9 +35,9 @@ class LevelRepositoryTest {
 
         levelRepository.save(level);
 
-        //when
-        Level findLevel = levelRepository.findLevelByName(level.getName())
-            .orElseThrow(() -> new BusinessException(LevelErrorCode.LEVEL_NOT_FOUND));
+		//when
+		Level findLevel = levelRepository.findByName(level.getName())
+			.orElseThrow(() -> new BusinessException(LevelErrorCode.LEVEL_NOT_FOUND));
 
         //then
         assertThat(findLevel.getId()).isEqualTo(level.getId());

--- a/src/test/java/com/kernel360/kernelsquare/global/jwt/TokenProviderTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/global/jwt/TokenProviderTest.java
@@ -1,0 +1,227 @@
+package com.kernel360.kernelsquare.global.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.kernel360.kernelsquare.domain.auth.dto.LoginRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.TokenRequest;
+import com.kernel360.kernelsquare.domain.auth.dto.TokenResponse;
+import com.kernel360.kernelsquare.domain.auth.entity.RefreshToken;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@DisplayName("토큰 생성 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+public class TokenProviderTest {
+	@InjectMocks
+	private TokenProvider tokenProvider;
+	@Spy
+	private RedisTemplate<Long, RefreshToken> redisTemplate = spy(RedisTemplate.class);
+
+	@Mock
+	private AuthenticationManagerBuilder authenticationManagerBuilder;
+
+	private String secret = "dGVzdF9zZWNyZXRfdGVzdF9zZWNyZXRfdGVzdF9zZWNyZXRfdGVzdF9zZWNyZXRfdGVzdF9zZWNyZXRfdGVzdF9zZWNyZXRfdGVzdF9zZWNyZXRfdGVzdF9zZWNyZXRfdGVzdF9zZWNyZXRfdGVzdF9zZWNyZXRf";
+
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	@BeforeEach
+	public void setUp() {
+		byte[] keyBytes = Decoders.BASE64.decode(secret);
+		ReflectionTestUtils.setField(tokenProvider, "key", Keys.hmacShaKeyFor(keyBytes));
+
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+		String classPropertyTypeName = "RefreshToken.class";
+		GenericJackson2JsonRedisSerializer jsonRedisSerializer =
+			new GenericJackson2JsonRedisSerializer(classPropertyTypeName);
+		jsonRedisSerializer.configure(objectMapper -> objectMapper
+			.registerModule(new JavaTimeModule()));
+
+		LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory();
+		lettuceConnectionFactory.afterPropertiesSet();
+
+		redisTemplate.setConnectionFactory(lettuceConnectionFactory);
+		redisTemplate.setKeySerializer(new JdkSerializationRedisSerializer());
+		redisTemplate.setValueSerializer(jsonRedisSerializer);
+		redisTemplate.afterPropertiesSet();
+	}
+
+	@Test
+	@DisplayName("jwt 생성 테스트")
+	void testCreateToken() throws Exception {
+		//given
+		String email = "jugwang@naver.com";
+		String password = "hashed_password";
+
+		Member member = Member
+			.builder()
+			.id(1L)
+			.nickname("hongjugwang")
+			.email(email)
+			.password(password)
+			.experience(10000L)
+			.introduction("hi, i'm hongjugwang.")
+			.imageUrl("s3:qwe12fasdawczx")
+			.build();
+
+		LoginRequest loginRequest = LoginRequest.builder()
+			.email(email)
+			.password(password)
+			.build();
+
+		RefreshToken refreshToken = RefreshToken.builder()
+			.memberId(member.getId())
+			.refreshToken("awdawdawdawdawd")
+			.createdDate(LocalDateTime.now())
+			.expirationDate(LocalDateTime.now().plusDays(10))
+			.build();
+
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+			new UsernamePasswordAuthenticationToken(member.getId(), password);
+
+		Authentication authentication = mock(Authentication.class);
+
+		AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+
+		doReturn(authenticationManager)
+			.when(authenticationManagerBuilder)
+			.getObject();
+
+		doReturn(authentication)
+			.when(authenticationManager)
+			.authenticate(usernamePasswordAuthenticationToken);
+
+		doReturn(String.valueOf(member.getId()))
+			.when(authentication)
+			.getName();
+
+		//when
+		TokenResponse tokenResponse = tokenProvider.createToken(member, loginRequest);
+
+		RefreshToken createdRefreshToken = objectMapper.readValue(Decoders.BASE64
+			.decode(tokenResponse.refreshToken()), RefreshToken.class);
+
+		//then
+		assertThat(createdRefreshToken.getMemberId()).isEqualTo(member.getId());
+
+		//verify
+		verify(authenticationManagerBuilder, times(1)).getObject();
+		verify(authenticationManager, times(1)).authenticate(any(Authentication.class));
+		verify(authentication, times(2)).getName();
+	}
+
+	@Test
+	@DisplayName("로그 아웃 테스트")
+	void testLogout() throws Exception {
+		//given
+		Long testMemberId = 1L;
+		String accessToken = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTkwMDAwMDAwMH0.eHSaEoaFl9Rb7R6YxwyKiACOObHN0XjiNO7T7i1KpkiqVbgz9hQr5EPq5DuRliA_UlsBeIvfU8UHPG7xhwdcRg";
+		String refreshTokenString = "eyJtZW1iZXJJZCI6MiwicmVmcmVzaFRva2VuIjoiMjYzOGUxYjQ3MmI2NDRkNTk4YzY1NGNlZWFlN2FhOTAiLCJjcmVhdGVkRGF0ZSI6IjIwMjQtMDEtMTBUMjE6MDA6MzIuNDYxOCIsImV4cGlyYXRpb25EYXRlIjoiMjAyNC0wMS0yNFQyMTowMDozMi40NjE3NiJ9";
+
+		TokenRequest tokenRequest = TokenRequest.builder()
+			.refreshToken(refreshTokenString)
+			.accessToken(accessToken)
+			.build();
+
+		ValueOperations<Long, RefreshToken> longRefreshTokenValueOperations = mock(ValueOperations.class);
+
+		RedisOperations<Long, RefreshToken> operations = mock(RedisOperations.class);
+
+		doReturn(longRefreshTokenValueOperations)
+			.when(redisTemplate)
+			.opsForValue();
+
+		doReturn(operations)
+			.when(longRefreshTokenValueOperations)
+			.getOperations();
+
+		doReturn(Boolean.TRUE)
+			.when(operations)
+			.delete(anyLong());
+
+		//when
+		tokenProvider.logout(tokenRequest);
+		Boolean delete = redisTemplate.opsForValue().getOperations().delete(testMemberId);
+
+		//then
+		assertThat(delete).isTrue();
+
+		//verify
+		verify(redisTemplate, times(2)).opsForValue();
+		verify(redisTemplate.opsForValue(), times(2)).getOperations();
+		verify(redisTemplate.opsForValue().getOperations(), times(2)).delete(anyLong());
+	}
+
+	/**
+	 * AccessToken은 만료 시간을 들고 있어서 이 코드 대로면 시간이 지나면 항상 테스트가 터져버림..
+	 * 따라서 임의로 AccessToken 만료 기한을 2030년까지로 설정하여 일단 테스트가 통과 될 수 있도록 지정 해놓음
+	 */
+	@Test
+	@DisplayName("토큰 재발급 테스트")
+	void testReissueToken() throws Exception {
+		//given
+		String accessToken = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTkwMDAwMDAwMH0.eHSaEoaFl9Rb7R6YxwyKiACOObHN0XjiNO7T7i1KpkiqVbgz9hQr5EPq5DuRliA_UlsBeIvfU8UHPG7xhwdcRg";
+
+		String refreshTokenString = "eyJtZW1iZXJJZCI6MiwicmVmcmVzaFRva2VuIjoiMjYzOGUxYjQ3MmI2NDRkNTk4YzY1NGNlZWFlN2FhOTAiLCJjcmVhdGVkRGF0ZSI6IjIwMjQtMDEtMTBUMjE6MDA6MzIuNDYxOCIsImV4cGlyYXRpb25EYXRlIjoiMjAyNC0wMS0yNFQyMTowMDozMi40NjE3NiJ9";
+
+		TokenRequest tokenRequest = TokenRequest
+			.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshTokenString)
+			.build();
+
+		RefreshToken refreshToken = objectMapper.readValue(Decoders.BASE64
+			.decode(refreshTokenString), RefreshToken.class);
+
+		ValueOperations<Long, RefreshToken> longRefreshTokenValueOperations = mock(ValueOperations.class);
+
+		doReturn(longRefreshTokenValueOperations)
+			.when(redisTemplate)
+			.opsForValue();
+
+		doReturn(refreshToken)
+			.when(longRefreshTokenValueOperations)
+			.get(anyLong());
+
+		//when
+		TokenResponse tokenResponse = tokenProvider.reissueToken(tokenRequest);
+		RefreshToken createdRefreshToken = objectMapper.readValue(Decoders.BASE64.decode(tokenResponse.refreshToken()),
+			RefreshToken.class);
+
+		//then
+		assertThat(createdRefreshToken.getMemberId()).isEqualTo(refreshToken.getMemberId());
+
+		//verify
+		verify(redisTemplate, times(2)).opsForValue();
+		verify(redisTemplate.opsForValue(), times(1)).get(anyLong());
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -36,9 +36,10 @@ spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
 
-#  redis:
-#    host: localhost
-#    port: 6379
+  data:
+    redis:
+      host: localhost
+      port: 6380
 
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #100 #96 

## 개요
- 인증 관련된 테스트들이 작성되어 있지 않아 새로 추가하였습니다.
- 인증 관련된 서비스와 컨트롤러 내부 로직을 리팩토링하여 하나의 서비스에 너무 많은 책임이 몰려 있지 않도록 했습니다.
- 그 외 서비스 내부도 리팩토링하여 불필요한 라인들을 삭제하고 하나의 메서드에 남도록 하였습니다.
- 기존에 ``AssertThatThrownBy``를 사용하면 내부 값을 테스트 할 수 없었던 경우를 이번 테스트에 새로이 알게된 ``extracting``을 통해 내부 에러코드 또한 확인할 수 있도록 하였습니다.

## 상세 내용
- RefreshToken이 인코딩 되지 않고 클라이언트에 보내지던 현상을 막았습니다.
- 그와 관련하여 내부의 토큰이 제대로 동작하는지 확인하기 위해 각 서비스와 컨트롤러에 대한 테스트를 작성하였습니다.
- 이외에 TokenDTO를 응답과 요청 DTO로 분리하였습니다
