### PR TITLE
[feat] 커피챗 예약 게시글 생성

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/authority/entity/Authority.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/authority/entity/Authority.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,4 +27,10 @@ public class Authority {
 	@Enumerated(value = EnumType.STRING)
 	@Column(nullable = false, name = "authority_type", columnDefinition = "varchar(20)")
 	private AuthorityType authorityType;
+
+	@Builder
+	public Authority(Long id, AuthorityType authorityType) {
+		this.id = id;
+		this.authorityType = authorityType;
+	}
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/entity/HashTag.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/entity/HashTag.java
@@ -1,0 +1,32 @@
+package com.kernel360.kernelsquare.domain.hashtag.entity;
+
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+import com.kernel360.kernelsquare.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "hashtag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HashTag extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false ,name = "content", columnDefinition = "varchar(30)")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_article_id", columnDefinition = "bigint", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private ReservationArticle reservationArticle;
+
+    @Builder
+    public HashTag(Long id, String content, ReservationArticle reservationArticle) {
+        this.id = id;
+        this.content = content;
+        this.reservationArticle = reservationArticle;
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/entity/HashTag.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/entity/HashTag.java
@@ -29,4 +29,5 @@ public class HashTag extends BaseEntity {
         this.content = content;
         this.reservationArticle = reservationArticle;
     }
+
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/repository/HashTagRepository.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/repository/HashTagRepository.java
@@ -1,0 +1,7 @@
+package com.kernel360.kernelsquare.domain.hashtag.repository;
+
+import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashTagRepository extends JpaRepository<HashTag, Long> {
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
@@ -1,10 +1,8 @@
 package com.kernel360.kernelsquare.domain.reservation.entity;
 
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
 import com.kernel360.kernelsquare.global.entity.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,5 +14,9 @@ public class Reservation extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_article_id", columnDefinition = "bigint", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private ReservationArticle reservationArticle;
 
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
@@ -1,0 +1,20 @@
+package com.kernel360.kernelsquare.domain.reservation.entity;
+
+import com.kernel360.kernelsquare.global.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reservation extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticle.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticle.java
@@ -1,0 +1,34 @@
+package com.kernel360.kernelsquare.domain.reservation_article.controller;
+
+import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.service.ReservationArticleService;
+import com.kernel360.kernelsquare.global.common_response.ApiResponse;
+import com.kernel360.kernelsquare.global.common_response.ResponseEntityFactory;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.kernel360.kernelsquare.global.common_response.response.code.ReservationArticleResponseCode.RESERVATION_ARTICLE_CREATED;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ReservationArticle {
+
+    private final ReservationArticleService reservationArticleService;
+    @PostMapping("/coffeechat/posts")
+    public ResponseEntity<ApiResponse<CreateReservationArticleResponse>> createReservationArticle(
+            @Valid
+            @RequestBody
+            CreateReservationArticleRequest createReservationArticleRequest
+    ) {
+        CreateReservationArticleResponse createReservationArticleResponse = reservationArticleService.createReservationArticle(createReservationArticleRequest);
+
+        return ResponseEntityFactory.toResponseEntity(RESERVATION_ARTICLE_CREATED, createReservationArticleResponse);
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleController.java
@@ -18,7 +18,7 @@ import static com.kernel360.kernelsquare.global.common_response.response.code.Re
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-public class ReservationArticle {
+public class ReservationArticleController {
 
     private final ReservationArticleService reservationArticleService;
     @PostMapping("/coffeechat/posts")

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/CreateReservationArticleRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/CreateReservationArticleRequest.java
@@ -17,6 +17,7 @@ public record CreateReservationArticleRequest(
         String title,
         @NotBlank(message = "내용을 작성해주세요.")
         String content,
+        @NotNull(message = "빈 리스트라도 보내주세요")
         List<String> hashTags,
         @NotNull(message = "시간을 선택해주세요.")
         List<LocalDateTime> dateTimes

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/CreateReservationArticleRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/CreateReservationArticleRequest.java
@@ -4,6 +4,7 @@ import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/CreateReservationArticleRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/CreateReservationArticleRequest.java
@@ -1,0 +1,31 @@
+package com.kernel360.kernelsquare.domain.reservation_article.dto;
+
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+public record CreateReservationArticleRequest(
+        @NotNull(message = "멤버 ID는 필수 항목입니다.")
+        Long memberId,
+        @NotBlank(message = "제목을 입력해주세요.")
+        String title,
+        @NotBlank(message = "내용을 작성해주세요.")
+        String content,
+        List<String> hashTags,
+        @NotNull(message = "시간을 선택해주세요.")
+        List<LocalDateTime> dateTimes
+)  {
+        public static ReservationArticle toEntity(CreateReservationArticleRequest createReservationArticleRequest, Member member) {
+                return ReservationArticle.builder()
+                        .title(createReservationArticleRequest.title())
+                        .content(createReservationArticleRequest.content())
+                        .member(member)
+                        .build();
+        }
+
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/CreateReservationArticleResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/CreateReservationArticleResponse.java
@@ -1,0 +1,13 @@
+package com.kernel360.kernelsquare.domain.reservation_article.dto;
+
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+
+public record CreateReservationArticleResponse(
+        Long reservationArticleId
+) {
+    public static CreateReservationArticleResponse from(ReservationArticle reservationArticle) {
+        return new CreateReservationArticleResponse(
+                reservationArticle.getId()
+        );
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
@@ -2,6 +2,7 @@ package com.kernel360.kernelsquare.domain.reservation_article.entity;
 
 import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.reservation.entity.Reservation;
 import com.kernel360.kernelsquare.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -31,6 +32,8 @@ public class ReservationArticle extends BaseEntity {
 
     @OneToMany(mappedBy = "reservationArticle")
     private List<HashTag> hashTagList = new ArrayList<>();
+
+
 
 
 

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
@@ -1,0 +1,51 @@
+package com.kernel360.kernelsquare.domain.reservation_article.entity;
+
+import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity(name = "reservation_article")
+@Getter
+@NoArgsConstructor
+public class ReservationArticle extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false, name = "title", columnDefinition = "varchar(50)")
+    private String title;
+
+    @Column(nullable = false, name = "content", columnDefinition = "text")
+    private String content;
+
+    @OneToMany(mappedBy = "reservationArticle")
+    private List<HashTag> hashTagList = new ArrayList<>();
+
+
+
+    @Builder
+    public ReservationArticle(Long id, Member member, String title, String content, List<HashTag> hashTagList) {
+        this.id = id;
+        this.member = member;
+        this.title = title;
+        this.content = content;
+        this.hashTagList = hashTagList;
+    }
+
+    public void update(String title, String content, List<HashTag> hashTagList) {
+        this.title = title;
+        this.content = content;
+        this.hashTagList = new ArrayList<>();
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
@@ -2,7 +2,6 @@ package com.kernel360.kernelsquare.domain.reservation_article.entity;
 
 import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
-import com.kernel360.kernelsquare.domain.reservation.entity.Reservation;
 import com.kernel360.kernelsquare.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -33,10 +32,6 @@ public class ReservationArticle extends BaseEntity {
     @OneToMany(mappedBy = "reservationArticle")
     private List<HashTag> hashTagList = new ArrayList<>();
 
-
-
-
-
     @Builder
     public ReservationArticle(Long id, Member member, String title, String content, List<HashTag> hashTagList) {
         this.id = id;
@@ -49,6 +44,6 @@ public class ReservationArticle extends BaseEntity {
     public void update(String title, String content, List<HashTag> hashTagList) {
         this.title = title;
         this.content = content;
-        this.hashTagList = new ArrayList<>();
+        this.hashTagList = hashTagList;
     }
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/repository/ReservationArticleRepository.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/repository/ReservationArticleRepository.java
@@ -1,0 +1,8 @@
+package com.kernel360.kernelsquare.domain.reservation_article.repository;
+
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationArticleRepository extends JpaRepository<ReservationArticle, Long> {
+
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
@@ -31,11 +31,6 @@ public class ReservationArticleService {
         Authority authority = authorityRepository.findAuthorityByAuthorityType(AuthorityType.ROLE_MENTOR)
                 .orElseThrow(() -> new BusinessException(AuthorityErrorCode.AUTHORITY_NOT_FOUND));
 
-        if (!authority.getAuthorityType().equals(AuthorityType.ROLE_MENTOR)) {
-            throw new BusinessException(AuthorityErrorCode.AUTHORITY_NOT_FOUND);
-        }
-
-
         ReservationArticle reservationArticle = CreateReservationArticleRequest.toEntity(createReservationArticleRequest, member);
         ReservationArticle saveReservationArticle = reservationArticleRepository.save(reservationArticle);
 

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
@@ -1,0 +1,46 @@
+package com.kernel360.kernelsquare.domain.reservation_article.service;
+
+import com.kernel360.kernelsquare.domain.authority.entity.Authority;
+import com.kernel360.kernelsquare.domain.authority.repository.AuthorityRepository;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+import com.kernel360.kernelsquare.domain.reservation_article.repository.ReservationArticleRepository;
+import com.kernel360.kernelsquare.global.common_response.error.code.AuthorityErrorCode;
+import com.kernel360.kernelsquare.global.common_response.error.code.MemberErrorCode;
+import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
+import com.kernel360.kernelsquare.global.domain.AuthorityType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationArticleService {
+    private final MemberRepository memberRepository;
+    private final AuthorityRepository authorityRepository;
+    private final ReservationArticleRepository reservationArticleRepository;
+
+    @Transactional
+    public CreateReservationArticleResponse createReservationArticle(CreateReservationArticleRequest createReservationArticleRequest) {
+        Member member = memberRepository.findById(createReservationArticleRequest.memberId())
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Authority authority = authorityRepository.findAuthorityByAuthorityType(AuthorityType.ROLE_MENTOR)
+                .orElseThrow(() -> new BusinessException(AuthorityErrorCode.AUTHORITY_NOT_FOUND));
+
+        if (!authority.getAuthorityType().equals(AuthorityType.ROLE_MENTOR)) {
+            throw new BusinessException(AuthorityErrorCode.AUTHORITY_NOT_FOUND);
+        }
+
+
+        ReservationArticle reservationArticle = CreateReservationArticleRequest.toEntity(createReservationArticleRequest, member);
+        ReservationArticle saveReservationArticle = reservationArticleRepository.save(reservationArticle);
+
+        return CreateReservationArticleResponse.from(saveReservationArticle);
+    }
+
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
@@ -28,8 +28,6 @@ public class ReservationArticleService {
     public CreateReservationArticleResponse createReservationArticle(CreateReservationArticleRequest createReservationArticleRequest) {
         Member member = memberRepository.findById(createReservationArticleRequest.memberId())
                 .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
-        Authority authority = authorityRepository.findAuthorityByAuthorityType(AuthorityType.ROLE_MENTOR)
-                .orElseThrow(() -> new BusinessException(AuthorityErrorCode.AUTHORITY_NOT_FOUND));
 
         ReservationArticle reservationArticle = CreateReservationArticleRequest.toEntity(createReservationArticleRequest, member);
         ReservationArticle saveReservationArticle = reservationArticleRepository.save(reservationArticle);

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/ReservationArticleResponseCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/ReservationArticleResponseCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReservationArticleResponseCode implements ResponseCode {
     RESERVATION_ARTICLE_CREATED(HttpStatus.OK,
-            ReservationArticleServiceStatus.RESERVATION_ARTICLE_CREATED, "게시글이 생성되었습니다.");
+            ReservationArticleServiceStatus.RESERVATION_ARTICLE_CREATED, "예약창이 생성되었습니다.");
 
     private final HttpStatus httpStatus;
     private final ServiceStatus serviceStatus;

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/ReservationArticleResponseCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/ReservationArticleResponseCode.java
@@ -1,0 +1,31 @@
+package com.kernel360.kernelsquare.global.common_response.response.code;
+
+import com.kernel360.kernelsquare.global.common_response.service.code.ReservationArticleServiceStatus;
+import com.kernel360.kernelsquare.global.common_response.service.code.ServiceStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ReservationArticleResponseCode implements ResponseCode {
+    RESERVATION_ARTICLE_CREATED(HttpStatus.OK,
+            ReservationArticleServiceStatus.RESERVATION_ARTICLE_CREATED, "게시글이 생성되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final ServiceStatus serviceStatus;
+    private final String msg;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public Integer getCode() {
+        return serviceStatus.getServiceStatus();
+    }
+
+    @Override
+    public String getMsg() {
+        return msg;
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/ReservationArticleServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/ReservationArticleServiceStatus.java
@@ -1,0 +1,19 @@
+package com.kernel360.kernelsquare.global.common_response.service.code;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ReservationArticleServiceStatus implements ServiceStatus {
+    //error
+
+
+    //success
+    RESERVATION_ARTICLE_CREATED(3140);
+
+
+    private final Integer code;
+
+    @Override
+    public Integer getServiceStatus() { return code;}
+
+}

--- a/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
@@ -93,6 +93,10 @@ public class SecurityConfig {
 			.requestMatchers(HttpMethod.PUT, "/api/v1/questions/{questionId}").hasRole("USER")
 			.requestMatchers(HttpMethod.DELETE, "/api/v1/questions/{questionId}").hasRole("USER")
 
+			// ROLE_MENTOR 권한 필요
+			.requestMatchers(HttpMethod.POST, "/api/v1/coffeechat/posts").permitAll()
+			.requestMatchers(HttpMethod.POST, "/api/v1/coffeechat/posts").hasRole("MENTOR")
+
 			// ROLE_ADMIN 권한 필요
 			.requestMatchers(hasRoleAdminPatterns).hasRole("ADMIN")
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,7 @@ spring:
 logging.level:
   org.hibernate.SQL: debug
   #  org.hibernate.type: trace
-  org.springframework.security: warn
+  org.springframework.security: debug
 
 cloud:
   aws:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -35,7 +35,7 @@ INSERT INTO authority (authority_type)
 VALUES ('ROLE_MENTOR');
 
 INSERT INTO member_authority (member_id, authority_id)
-VALUES (1, 1)
+VALUES (1, 1);
 
 INSERT INTO level (created_date, modified_date, image_url, name, level_upper_limit)
 VALUES ('2023-12-12T09:00:00', '2023-12-12T09:00:00', 'level/level3to4.png', 3, 1800);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -18,5 +18,8 @@ VALUES ('2023-12-12T09:00:00', '2023-12-12T09:00:00', 'level/level1to2.png', 1);
 INSERT INTO authority (authority_type)
 VALUES ('ROLE_USER');
 
+INSERT INTO authority (authority_type)
+VALUES ('ROLE_MENTOR');
+
 INSERT INTO member_authority (member_id, authority_id)
 VALUES (1, 1)

--- a/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
@@ -1,0 +1,99 @@
+package com.kernel360.kernelsquare.domain.reservation_article.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+import com.kernel360.kernelsquare.domain.reservation_article.service.ReservationArticleService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.kernel360.kernelsquare.global.common_response.response.code.ReservationArticleResponseCode.RESERVATION_ARTICLE_CREATED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("커피챗 예약게시글 컨트롤러 단위 테스트")
+@WebMvcTest(ReservationArticleController.class)
+class ReservationArticleControllerTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private ReservationArticleService reservationArticleService;
+
+    Member member;
+
+    private ReservationArticle createTestReservationArticle(Long id) {
+        return ReservationArticle.builder()
+                .id(id)
+                .title("testplz")
+                .content("ahahahahahhhh")
+                .hashTagList(List.of())
+                .build();
+    }
+
+    private Member createTestMember() {
+        return Member.builder()
+            .id(1L)
+            .nickname("hongjugwang")
+            .email("jugwang@naver.com")
+            .password("hashedPassword")
+            .experience(10000L)
+            .introduction("hi, i'm hongjugwang.")
+            .imageUrl("s3:qwe12fasdawczx")
+            .build();
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("예약게시글 생성 성공시 200 OK 와 응답 메시지를 반환한다.")
+    void testCreateReservationArticle() throws Exception {
+        // Given
+
+        member = createTestMember();
+        ReservationArticle reservationArticle = createTestReservationArticle(1L);
+
+        CreateReservationArticleRequest createReservationArticleRequest =
+                new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(), reservationArticle.getContent(),
+                reservationArticle.getHashTagList().stream().map(o -> o.getContent()).toList(), List.of(LocalDateTime.now(),LocalDateTime.now().plusDays(2)));
+
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        objectMapper.registerModule(new JavaTimeModule());
+        String jsonRequest = objectMapper.writeValueAsString(createReservationArticleRequest);
+
+
+        given(reservationArticleService.createReservationArticle(any(CreateReservationArticleRequest.class))).willReturn(CreateReservationArticleResponse.from(reservationArticle));
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/coffeechat/posts")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8")
+                        .content(jsonRequest))
+                .andExpect(status().is(RESERVATION_ARTICLE_CREATED.getStatus().value()))
+                .andExpect(jsonPath("$.code").value(RESERVATION_ARTICLE_CREATED.getCode()))
+                .andExpect(jsonPath("$.msg").value(RESERVATION_ARTICLE_CREATED.getMsg()));
+
+        // Verify
+        verify(reservationArticleService, times(1)).createReservationArticle(any(CreateReservationArticleRequest.class));
+    }
+}

--- a/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
@@ -3,6 +3,7 @@ package com.kernel360.kernelsquare.domain.reservation_article.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
@@ -39,7 +40,7 @@ class ReservationArticleControllerTest {
     @MockBean
     private ReservationArticleService reservationArticleService;
 
-    Member member;
+    private Member member;
 
     private ReservationArticle createTestReservationArticle(Long id) {
         return ReservationArticle.builder()
@@ -73,7 +74,7 @@ class ReservationArticleControllerTest {
 
         CreateReservationArticleRequest createReservationArticleRequest =
                 new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(), reservationArticle.getContent(),
-                reservationArticle.getHashTagList().stream().map(o -> o.getContent()).toList(), List.of(LocalDateTime.now(),LocalDateTime.now().plusDays(2)));
+                reservationArticle.getHashTagList().stream().map(HashTag::getContent).toList(), List.of(LocalDateTime.now(),LocalDateTime.now().plusDays(2)));
 
         objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         objectMapper.registerModule(new JavaTimeModule());

--- a/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleServiceTest.java
@@ -1,0 +1,119 @@
+package com.kernel360.kernelsquare.domain.reservation_article.service;
+
+import com.kernel360.kernelsquare.domain.authority.entity.Authority;
+import com.kernel360.kernelsquare.domain.authority.repository.AuthorityRepository;
+import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
+import com.kernel360.kernelsquare.domain.member_authority.entity.MemberAuthority;
+import com.kernel360.kernelsquare.domain.member_authority.repository.MemberAuthorityRepository;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+import com.kernel360.kernelsquare.domain.reservation_article.repository.ReservationArticleRepository;
+import com.kernel360.kernelsquare.global.domain.AuthorityType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("커피챗 예약게시글 서비스 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class ReservationArticleServiceTest {
+    @InjectMocks
+    private ReservationArticleService reservationArticleService;
+    @Mock
+    private ReservationArticleRepository reservationArticleRepository;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private MemberAuthorityRepository memberAuthorityRepository;
+    @Mock
+    private AuthorityRepository authorityRepository;
+
+    private Member member;
+    private Authority authority;
+    private MemberAuthority memberRole;
+
+    private ReservationArticle createTestReservationArticle(Long id) {
+        return ReservationArticle.builder()
+                .id(id)
+                .title("testplz")
+                .content("ahahahahahhhh")
+                .hashTagList(List.of())
+                .build();
+    }
+
+    private Member createTestMember() {
+        return Member.builder()
+                .id(1L)
+                .nickname("hongjugwang")
+                .email("jugwang@naver.com")
+                .password("hashedPassword")
+                .experience(10000L)
+                .introduction("hi, i'm hongjugwang.")
+                .imageUrl("s3:qwe12fasdawczx")
+                .build();
+    }
+
+    private MemberAuthority createTestRole(Member member, Authority authority) {
+        return MemberAuthority.builder()
+                .member(member)
+                .authority(authority)
+                .build();
+    }
+
+    @Test
+    @DisplayName("예약게시글 생성 테스트")
+    void testCreateReservationArticle() {
+        // Given
+        member = createTestMember();
+        authority = createTestAuthority();
+        memberRole = createTestRole(member, authority);
+
+        List<MemberAuthority> memberAuthorityList = List.of(memberRole);
+
+        member.initAuthorities(memberAuthorityList);
+
+        ReservationArticle reservationArticle = createTestReservationArticle(1L);
+
+        CreateReservationArticleRequest createReservationArticleRequest =
+                new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(), reservationArticle.getContent(),
+                        reservationArticle.getHashTagList().stream().map(HashTag::getContent).toList(), List.of(LocalDateTime.now(),LocalDateTime.now().plusDays(2)));
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
+        given(authorityRepository.findAuthorityByAuthorityType(any(AuthorityType.class))).willReturn(Optional.ofNullable(authority));
+        given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
+
+        // When
+        CreateReservationArticleResponse createReservationArticleResponse = reservationArticleService.createReservationArticle(createReservationArticleRequest);
+
+        // Then
+        assertThat(createReservationArticleResponse).isNotNull();
+        assertThat(createReservationArticleResponse.reservationArticleId()).isEqualTo(reservationArticle.getId());
+
+        // Verify
+        verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
+    }
+
+    private Authority createTestAuthority() {
+        return Authority.builder()
+                .id(1L)
+                .authorityType(AuthorityType.ROLE_MENTOR)
+                .build();
+    }
+}

--- a/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleServiceTest.java
@@ -96,7 +96,6 @@ class ReservationArticleServiceTest {
                         reservationArticle.getHashTagList().stream().map(HashTag::getContent).toList(), List.of(LocalDateTime.now(),LocalDateTime.now().plusDays(2)));
 
         given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
-        given(authorityRepository.findAuthorityByAuthorityType(any(AuthorityType.class))).willReturn(Optional.ofNullable(authority));
         given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
 
         // When


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #85 

## 개요
> 커피챗 예약 게시글 생성

## 상세 내용
- 예약 게시글 엔티티, 예약 엔티티, 해시태그 엔티티 생성
- 예약 게시글 서비스, 컨트롤러 Create 생성
- data.sql 에 멘토 추가
- SecurityConfig 에 멘토 permitAll, hasRole 추가
- 테스트 코드 작성
