### PR TITLE
[bugfix] 로그인 응답 ROLE 정상적으로 보내주도록 LoginResponse 수정

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
@@ -7,6 +7,7 @@ import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member_authority.entity.MemberAuthority;
 
+import com.kernel360.kernelsquare.global.domain.AuthorityType;
 import lombok.Builder;
 
 @Builder
@@ -26,7 +27,7 @@ public record LoginResponse(
 		List<String> roles = member.getAuthorities().stream()
 			.map(MemberAuthority::getAuthority)
 			.map(Authority::getAuthorityType)
-			.map(String::valueOf)
+			.map(AuthorityType::getDescription)
 			.toList();
 
 		return LoginResponse.builder()

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
@@ -3,6 +3,7 @@ package com.kernel360.kernelsquare.domain.auth.dto;
 import java.util.List;
 
 import com.kernel360.kernelsquare.domain.authority.entity.Authority;
+import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member_authority.entity.MemberAuthority;
 
@@ -33,7 +34,7 @@ public record LoginResponse(
 			.nickname(member.getNickname())
 			.experience(member.getExperience())
 			.introduction(member.getIntroduction())
-			.imageUrl(member.getImageUrl())
+			.imageUrl(ImageUtils.makeImageUrl(member.getImageUrl()))
 			.level(member.getLevel().getName())
 			.roles(roles)
 			.tokenDto(tokenResponse)

--- a/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/auth/dto/LoginResponse.java
@@ -2,6 +2,7 @@ package com.kernel360.kernelsquare.domain.auth.dto;
 
 import java.util.List;
 
+import com.kernel360.kernelsquare.domain.authority.entity.Authority;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member_authority.entity.MemberAuthority;
 
@@ -23,6 +24,7 @@ public record LoginResponse(
 	public static LoginResponse of(Member member, TokenResponse tokenResponse) {
 		List<String> roles = member.getAuthorities().stream()
 			.map(MemberAuthority::getAuthority)
+			.map(Authority::getAuthorityType)
 			.map(String::valueOf)
 			.toList();
 


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #108 

## 개요
> 프론트가 이해할 수 있는 문자열 형태로 보내주도록 하기 위함

## 상세 내용
- Authoriy객체 주소에서 Authoriy의 AuthorityType의 문자열을 보내주도록 LoginResponse 수정
- 추가적으로 member의 image_url을 절대 URL로 보내주도록 LoginResponse 수정
