### PR TITLE
[feat] 커피챗 - 예약창 조회

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/dto/ReservationDto.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/dto/ReservationDto.java
@@ -3,10 +3,11 @@ package com.kernel360.kernelsquare.domain.reservation.dto;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.reservation.entity.Reservation;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 
-
+@Builder
 public record ReservationDto(
         @NotNull LocalDateTime startTime,
         @NotNull Boolean finished,

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/dto/ReservationDto.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/dto/ReservationDto.java
@@ -1,0 +1,24 @@
+package com.kernel360.kernelsquare.domain.reservation.dto;
+
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.reservation.entity.Reservation;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+
+public record ReservationDto(
+        @NotNull LocalDateTime startTime,
+        @NotNull Boolean finished,
+        String memberNickname,
+        String memberImageUrl
+)  {
+    public static ReservationDto of(Reservation reservation, Member member) {
+        return new ReservationDto(
+                reservation.getStartTime(),
+                reservation.getFinished(),
+                member.getNickname(),
+                member.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
@@ -9,15 +9,22 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
-@Entity
+@Entity(name = "Reservation")
+@Table(name = "reservation")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reservation extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, name = "start_time", columnDefinition = "datetime")
     private LocalDateTime startTime;
+
+    @Column(nullable = false, name = "end_time", columnDefinition = "datetime")
     private LocalDateTime endTime;
+
+    @Column(nullable = false, name = "finished", columnDefinition = "tinyint")
     private Boolean finished;
 
     @ManyToOne

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
@@ -7,8 +7,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
-
 import java.time.LocalDateTime;
 
 @Entity
@@ -23,7 +21,7 @@ public class Reservation extends BaseEntity {
     private Boolean finished;
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/entity/Reservation.java
@@ -1,11 +1,15 @@
 package com.kernel360.kernelsquare.domain.reservation.entity;
 
+import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
 import com.kernel360.kernelsquare.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -14,6 +18,13 @@ public class Reservation extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private Boolean finished;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_article_id", columnDefinition = "bigint", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/repository/ReservationRepository.java
@@ -10,5 +10,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<ReservationDto> findAllByReservationArticleId(Long articleId);
 
-    Long countByIdAndMemberIdIsNull(Long id);
+    Long countByReservationArticleIdAndMemberIdIsNull(Long articleId);
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/repository/ReservationRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     List<ReservationDto> findAllByReservationArticleId(Long articleId);
+
+    Long countByIdAndMemberIdIsNull(Long id);
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,12 @@
+package com.kernel360.kernelsquare.domain.reservation.repository;
+
+import com.kernel360.kernelsquare.domain.reservation.dto.ReservationDto;
+import com.kernel360.kernelsquare.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    List<ReservationDto> findAllByReservationArticleId(Long articleId);
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleController.java
@@ -2,17 +2,21 @@ package com.kernel360.kernelsquare.domain.reservation_article.controller;
 
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.FindAllReservationArticleResponse;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.FindReservationArticleResponse;
 import com.kernel360.kernelsquare.domain.reservation_article.service.ReservationArticleService;
 import com.kernel360.kernelsquare.global.common_response.ApiResponse;
 import com.kernel360.kernelsquare.global.common_response.ResponseEntityFactory;
+import com.kernel360.kernelsquare.global.dto.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.kernel360.kernelsquare.global.common_response.response.code.ReservationArticleResponseCode.RESERVATION_ARTICLE_CREATED;
-import static com.kernel360.kernelsquare.global.common_response.response.code.ReservationArticleResponseCode.RESERVATION_ARTICLE_FOUND;
+import static com.kernel360.kernelsquare.global.common_response.response.code.ReservationArticleResponseCode.*;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -31,9 +35,16 @@ public class ReservationArticleController {
         return ResponseEntityFactory.toResponseEntity(RESERVATION_ARTICLE_CREATED, createReservationArticleResponse);
     }
 
-    // TODO 질문 목록 조회
+    @GetMapping("/coffeechat/posts")
+    public ResponseEntity<ApiResponse<PageResponse<FindAllReservationArticleResponse>>> findAllReservationArticle (
+        @PageableDefault(page = 0, size = 5, sort = "createdDate", direction = Sort.Direction.DESC)
+        Pageable pageable
+    ) {
+        PageResponse<FindAllReservationArticleResponse> pageResponse = reservationArticleService.findAllReservationArticle(pageable);
 
-    // TODO 질문 단건 조회
+        return ResponseEntityFactory.toResponseEntity(RESERVATION_ARTICLE_ALL_FOUND, pageResponse);
+    }
+
     @GetMapping("/coffeechat/posts/{postId}")
     public ResponseEntity<ApiResponse<FindReservationArticleResponse>> findReservationArticle(
         @PathVariable

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleController.java
@@ -2,18 +2,17 @@ package com.kernel360.kernelsquare.domain.reservation_article.controller;
 
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.FindReservationArticleResponse;
 import com.kernel360.kernelsquare.domain.reservation_article.service.ReservationArticleService;
 import com.kernel360.kernelsquare.global.common_response.ApiResponse;
 import com.kernel360.kernelsquare.global.common_response.ResponseEntityFactory;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.kernel360.kernelsquare.global.common_response.response.code.ReservationArticleResponseCode.RESERVATION_ARTICLE_CREATED;
+import static com.kernel360.kernelsquare.global.common_response.response.code.ReservationArticleResponseCode.RESERVATION_ARTICLE_FOUND;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -31,4 +30,17 @@ public class ReservationArticleController {
 
         return ResponseEntityFactory.toResponseEntity(RESERVATION_ARTICLE_CREATED, createReservationArticleResponse);
     }
+
+    // TODO 질문 목록 조회
+
+    // TODO 질문 단건 조회
+    @GetMapping("/coffeechat/posts/{postId}")
+    public ResponseEntity<ApiResponse<FindReservationArticleResponse>> findReservationArticle(
+        @PathVariable
+        Long postId
+    ) {
+        FindReservationArticleResponse findReservationArticleResponse = reservationArticleService.findReservationArticle(postId);
+        return ResponseEntityFactory.toResponseEntity(RESERVATION_ARTICLE_FOUND, findReservationArticleResponse);
+    }
+
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindAllReservationArticleResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindAllReservationArticleResponse.java
@@ -1,0 +1,42 @@
+package com.kernel360.kernelsquare.domain.reservation_article.dto;
+
+import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+public record FindAllReservationArticleResponse(
+        Long articleId,
+        Long memberId,
+        String nickname,
+        String memberImageUrl,
+        Long level,
+        String levelImageUrl,
+        String title,
+        List<String> hashTagList,
+        LocalDateTime createdDate,
+        LocalDateTime modifiedDate,
+        Long fullCheck
+) {
+    public static FindAllReservationArticleResponse of(
+            Member member,
+            ReservationArticle article,
+            Long fullCheck) {
+        return new FindAllReservationArticleResponse(
+                article.getId(),
+                member.getId(),
+                member.getNickname(),
+                ImageUtils.makeImageUrl(member.getImageUrl()),
+                member.getLevel().getName(),
+                ImageUtils.makeImageUrl(member.getLevel().getImageUrl()),
+                article.getTitle(),
+                article.getHashTagList().stream().map(String::valueOf).toList(),
+                article.getCreatedDate(),
+                article.getModifiedDate(),
+                fullCheck
+        );
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindReservationArticleResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindReservationArticleResponse.java
@@ -1,0 +1,47 @@
+package com.kernel360.kernelsquare.domain.reservation_article.dto;
+
+import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
+import com.kernel360.kernelsquare.domain.level.entity.Level;
+import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.reservation.dto.ReservationDto;
+import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FindReservationArticleResponse(
+        Long articleId,
+        Long memberId,
+        String nickname,
+        String memberImageUrl,
+        Long level,
+        String levelImageUrl,
+        String title,
+        String content,
+        List<String> hashTagList,
+        List<ReservationDto> dataTimes,
+        LocalDateTime createdDate,
+        LocalDateTime modifiedDate
+) {
+    public static FindReservationArticleResponse of(
+            Member member,
+            ReservationArticle article,
+            List<ReservationDto> reservationDtos,
+            Level level) {
+        return new FindReservationArticleResponse(
+                article.getId(),
+                member.getId(),
+                member.getNickname(),
+                ImageUtils.makeImageUrl(member.getImageUrl()),
+                level.getName(),
+                ImageUtils.makeImageUrl(level.getImageUrl()),
+                article.getTitle(),
+                article.getContent(),
+                article.getHashTagList().stream().map(String::valueOf).toList(),
+                reservationDtos,
+                article.getCreatedDate(),
+                article.getModifiedDate()
+        );
+
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
@@ -30,7 +30,7 @@ public class ReservationArticle extends BaseEntity {
     private String content;
 
     @OneToMany(mappedBy = "reservationArticle")
-    private List<HashTag> hashTagList = new ArrayList<>();
+    private List<HashTag> hashTagList;
 
     @Builder
     public ReservationArticle(Long id, Member member, String title, String content, List<HashTag> hashTagList) {

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity(name = "reservation_article")

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
@@ -43,10 +43,10 @@ public class ReservationArticleService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<FindAllReservationArticleResponse> findAllReservationArticle(Pageable pagealbe) {
+    public PageResponse<FindAllReservationArticleResponse> findAllReservationArticle(Pageable pageable) {
 
-        Integer currentPage = pagealbe.getPageNumber()+1;
-        Page<ReservationArticle> pages = reservationArticleRepository.findAll(pagealbe);
+        Integer currentPage = pageable.getPageNumber()+1;
+        Page<ReservationArticle> pages = reservationArticleRepository.findAll(pageable);
         Integer totalPages = pages.getTotalPages();
 
         if (totalPages == 0) totalPages += 1;
@@ -78,9 +78,9 @@ public class ReservationArticleService {
         ReservationArticle reservationArticle = reservationArticleRepository.findById(postId)
                 .orElseThrow(() -> new BusinessException(ReservationArticleErrorCode.RESERVATION_ARTICLE_NOT_FOUND));
         Member member = reservationArticle.getMember();
-        List<ReservationDto> reservationDTOS = reservationRepository.findAllByReservationArticleId(postId);
+        List<ReservationDto> reservationDTOs = reservationRepository.findAllByReservationArticleId(postId);
 
-        return FindReservationArticleResponse.of(member, reservationArticle, reservationDTOS, member.getLevel());
+        return FindReservationArticleResponse.of(member, reservationArticle, reservationDTOs, member.getLevel());
     }
 
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
@@ -59,7 +59,7 @@ public class ReservationArticleService {
 
         List<FindAllReservationArticleResponse> responsePages = pages.getContent().stream()
                 .map(article -> {
-                    Long fullCheck = reservationRepository.countByIdAndMemberIdIsNull(article.getId());
+                    Long fullCheck = reservationRepository.countByReservationArticleIdAndMemberIdIsNull(article.getId());
                     return FindAllReservationArticleResponse.of(
                             article.getMember(),
                             article,

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
@@ -1,28 +1,31 @@
 package com.kernel360.kernelsquare.domain.reservation_article.service;
 
-import com.kernel360.kernelsquare.domain.authority.entity.Authority;
 import com.kernel360.kernelsquare.domain.authority.repository.AuthorityRepository;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
+import com.kernel360.kernelsquare.domain.reservation.dto.ReservationDto;
+import com.kernel360.kernelsquare.domain.reservation.repository.ReservationRepository;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.FindReservationArticleResponse;
 import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
 import com.kernel360.kernelsquare.domain.reservation_article.repository.ReservationArticleRepository;
-import com.kernel360.kernelsquare.global.common_response.error.code.AuthorityErrorCode;
 import com.kernel360.kernelsquare.global.common_response.error.code.MemberErrorCode;
+import com.kernel360.kernelsquare.global.common_response.error.code.ReservationArticleErrorCode;
 import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
-import com.kernel360.kernelsquare.global.domain.AuthorityType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
 @RequiredArgsConstructor
 public class ReservationArticleService {
     private final MemberRepository memberRepository;
-    private final AuthorityRepository authorityRepository;
     private final ReservationArticleRepository reservationArticleRepository;
+    private final ReservationRepository reservationRepository;
 
     @Transactional
     public CreateReservationArticleResponse createReservationArticle(CreateReservationArticleRequest createReservationArticleRequest) {
@@ -33,6 +36,21 @@ public class ReservationArticleService {
         ReservationArticle saveReservationArticle = reservationArticleRepository.save(reservationArticle);
 
         return CreateReservationArticleResponse.from(saveReservationArticle);
+    }
+
+    // TODO 질문 목록 조회
+
+    // TODO 질문 단건 조회
+    @Transactional(readOnly = true)
+    public FindReservationArticleResponse findReservationArticle(
+            Long postId
+    ) {
+        ReservationArticle reservationArticle = reservationArticleRepository.findById(postId)
+                .orElseThrow(() -> new BusinessException(ReservationArticleErrorCode.RESERVATION_ARTICLE_NOT_FOUND));
+        Member member = reservationArticle.getMember();
+        List<ReservationDto> reservationDTOS = reservationRepository.findAllByReservationArticleId(postId);
+
+        return FindReservationArticleResponse.of(member, reservationArticle, reservationDTOS, member.getLevel());
     }
 
 }

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/error/code/ReservationArticleErrorCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/error/code/ReservationArticleErrorCode.java
@@ -1,4 +1,5 @@
-package com.kernel360.kernelsquare.global.common_response.response.code;
+package com.kernel360.kernelsquare.global.common_response.error.code;
+
 
 import com.kernel360.kernelsquare.global.common_response.service.code.ReservationArticleServiceStatus;
 import com.kernel360.kernelsquare.global.common_response.service.code.ServiceStatus;
@@ -6,11 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
-public enum ReservationArticleResponseCode implements ResponseCode {
-    RESERVATION_ARTICLE_CREATED(HttpStatus.OK,
-            ReservationArticleServiceStatus.RESERVATION_ARTICLE_CREATED, "예약창이 생성되었습니다."),
-    RESERVATION_ARTICLE_FOUND(HttpStatus.OK,
-            ReservationArticleServiceStatus.RESERVATION_ARTICLE_FOUND, "예약창을 조회했습니다.");
+public enum ReservationArticleErrorCode implements ErrorCode {
+
+    RESERVATION_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, ReservationArticleServiceStatus.RESERVATION_ARTICLE_NOT_FOUND, "존재하지 않는 예약창");
 
     private final HttpStatus httpStatus;
     private final ServiceStatus serviceStatus;

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/error/code/ReservationArticleErrorCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/error/code/ReservationArticleErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReservationArticleErrorCode implements ErrorCode {
 
-    RESERVATION_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, ReservationArticleServiceStatus.RESERVATION_ARTICLE_NOT_FOUND, "존재하지 않는 예약창");
+    RESERVATION_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, ReservationArticleServiceStatus.RESERVATION_ARTICLE_NOT_FOUND, "존재하지 않는 예약창"),
+    PAGE_NOT_FOUND(HttpStatus.NOT_FOUND, ReservationArticleServiceStatus.RESERVATION_ARTICLE_NOT_FOUND, "존재하지 않는 페이지");
+
 
     private final HttpStatus httpStatus;
     private final ServiceStatus serviceStatus;

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/error/code/ReservationArticleErrorCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/error/code/ReservationArticleErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ReservationArticleErrorCode implements ErrorCode {
 
     RESERVATION_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, ReservationArticleServiceStatus.RESERVATION_ARTICLE_NOT_FOUND, "존재하지 않는 예약창"),
-    PAGE_NOT_FOUND(HttpStatus.NOT_FOUND, ReservationArticleServiceStatus.RESERVATION_ARTICLE_NOT_FOUND, "존재하지 않는 페이지");
+    PAGE_NOT_FOUND(HttpStatus.NOT_FOUND, ReservationArticleServiceStatus.PAGE_NOT_FOUND, "존재하지 않는 페이지");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/ReservationArticleResponseCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/ReservationArticleResponseCode.java
@@ -10,7 +10,9 @@ public enum ReservationArticleResponseCode implements ResponseCode {
     RESERVATION_ARTICLE_CREATED(HttpStatus.OK,
             ReservationArticleServiceStatus.RESERVATION_ARTICLE_CREATED, "예약창이 생성되었습니다."),
     RESERVATION_ARTICLE_FOUND(HttpStatus.OK,
-            ReservationArticleServiceStatus.RESERVATION_ARTICLE_FOUND, "예약창을 조회했습니다.");
+            ReservationArticleServiceStatus.RESERVATION_ARTICLE_FOUND, "예약창을 조회했습니다."),
+    RESERVATION_ARTICLE_ALL_FOUND(HttpStatus.OK,
+            ReservationArticleServiceStatus.RESERVATION_ARTICLE_ALL_FOUND, "모든 예약창을 조회했습니다.");
 
     private final HttpStatus httpStatus;
     private final ServiceStatus serviceStatus;

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/ReservationArticleServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/ReservationArticleServiceStatus.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 public enum ReservationArticleServiceStatus implements ServiceStatus {
     //error
     RESERVATION_ARTICLE_NOT_FOUND(3100),
+    PAGE_NOT_FOUND(3101),
 
     //success
     RESERVATION_ARTICLE_CREATED(3140),

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/ReservationArticleServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/ReservationArticleServiceStatus.java
@@ -9,7 +9,9 @@ public enum ReservationArticleServiceStatus implements ServiceStatus {
 
     //success
     RESERVATION_ARTICLE_CREATED(3140),
-    RESERVATION_ARTICLE_FOUND(3141);
+    RESERVATION_ARTICLE_FOUND(3141),
+    RESERVATION_ARTICLE_ALL_FOUND(3142);
+
 
 
     private final Integer code;

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/ReservationArticleServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/ReservationArticleServiceStatus.java
@@ -5,10 +5,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ReservationArticleServiceStatus implements ServiceStatus {
     //error
-
+    RESERVATION_ARTICLE_NOT_FOUND(3100),
 
     //success
-    RESERVATION_ARTICLE_CREATED(3140);
+    RESERVATION_ARTICLE_CREATED(3140),
+    RESERVATION_ARTICLE_FOUND(3141);
 
 
     private final Integer code;

--- a/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
@@ -72,6 +72,8 @@ public class SecurityConfig {
 			.requestMatchers(HttpMethod.GET, "/api/v1/search/questions").permitAll()
 			.requestMatchers(HttpMethod.GET, "/api/v1/questions/{questiondId}/answers").permitAll()
 			.requestMatchers(HttpMethod.GET, "/api/v1/levels").permitAll()
+			.requestMatchers(HttpMethod.GET, "/api/v1/coffeechat/posts").permitAll()
+			.requestMatchers(HttpMethod.GET, "/api/v1/coffeechat/posts/{postId}").permitAll()
 
 			// 모든 권한에 대한 접근 허용
 			.requestMatchers(hasAnyAuthorityPatterns).authenticated()

--- a/src/main/resources/db/migration/V1.2__add_initial_data.sql
+++ b/src/main/resources/db/migration/V1.2__add_initial_data.sql
@@ -1,0 +1,51 @@
+CREATE TABLE `reservation`
+(
+    `id`                     BIGINT   NOT NULL,
+    `reservation_article_id` BIGINT   NOT NULL,
+    `member_id`              BIGINT   NULL,
+    `start_time`             DATETIME NOT NULL,
+    `end_time`               DATETIME NOT NULL,
+    `finished`               BOOLEAN DEFAULT '0',
+    `created_date` datetime NOT NULL,
+    `modified_date` datetime DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE `reservation_article`
+(
+    `id`        BIGINT       NOT NULL,
+    `member_id` BIGINT       NOT NULL,
+    `title`     VARCHAR(200) NOT NULL,
+    `content`   TEXT         NULL,
+    `created_date` datetime NOT NULL,
+    `modified_date` datetime DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE `hashtag`
+(
+    `id`                     BIGINT      NOT NULL,
+    `reservation_article_id` BIGINT      NOT NULL,
+    `content`                VARCHAR(30) NULL,
+    `created_date` datetime NOT NULL,
+    `modified_date` datetime DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+INSERT INTO reservation (id, reservation_article_id, member_id, start_time, end_time,finished,created_date,modified_date)
+VALUES (1, 1, 1, '2023-12-12T09:00:00', '2023-12-12T11:00:00', 0,'2023-12-12T11:00:00','2023-12-12T11:00:00');
+
+INSERT INTO reservation (id, reservation_article_id, member_id, start_time, end_time,finished,created_date,modified_date)
+VALUES (2, 1, null, '2023-12-12T13:00:00', '2023-12-12T14:00:00', 0,'2023-12-12T11:00:00','2023-12-12T11:00:00');
+
+INSERT INTO reservation_article (id, member_id, title, content,created_date,modified_date)
+VALUES (1, 1, 'title', 'No content','2023-12-12T11:00:00','2023-12-12T11:00:00');
+
+INSERT INTO reservation_article (id, member_id, title, content,created_date,modified_date)
+VALUES (2, 2, 'title2', 'No content2','2023-12-12T11:00:00','2023-12-12T11:00:00');

--- a/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
@@ -4,16 +4,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
+import com.kernel360.kernelsquare.domain.reservation.dto.ReservationDto;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.FindAllReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.FindReservationArticleResponse;
 import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
+import com.kernel360.kernelsquare.domain.reservation_article.repository.ReservationArticleRepository;
 import com.kernel360.kernelsquare.domain.reservation_article.service.ReservationArticleService;
+import com.kernel360.kernelsquare.global.dto.PageResponse;
+import com.kernel360.kernelsquare.global.dto.Pagination;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -21,15 +30,17 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.kernel360.kernelsquare.global.common_response.response.code.ReservationArticleResponseCode.RESERVATION_ARTICLE_CREATED;
+
+import static com.kernel360.kernelsquare.global.common_response.response.code.ReservationArticleResponseCode.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("커피챗 예약게시글 컨트롤러 단위 테스트")
 @WebMvcTest(ReservationArticleController.class)
@@ -41,6 +52,7 @@ class ReservationArticleControllerTest {
     private ReservationArticleService reservationArticleService;
 
     private Member member;
+    private Level level;
 
     private ReservationArticle createTestReservationArticle(Long id) {
         return ReservationArticle.builder()
@@ -60,7 +72,15 @@ class ReservationArticleControllerTest {
             .experience(10000L)
             .introduction("hi, i'm hongjugwang.")
             .imageUrl("s3:qwe12fasdawczx")
+            .level(level)
             .build();
+    }
+
+    private Level createTestLevel() {
+        return Level.builder()
+                .name(6L)
+                .imageUrl("1.jpg")
+                .build();
     }
 
     @Test
@@ -97,4 +117,97 @@ class ReservationArticleControllerTest {
         // Verify
         verify(reservationArticleService, times(1)).createReservationArticle(any(CreateReservationArticleRequest.class));
     }
+    @Test
+    @WithMockUser
+    @DisplayName("모든 예약게시글 조회 성공시 200 OK 와 응답 메시지를 반환한다.")
+    void testFindAllReservationArticle() throws Exception {
+        // Given
+        level = createTestLevel();
+        member = createTestMember();
+        ReservationArticle article1 = createTestReservationArticle(1L);
+        ReservationArticle article2 = createTestReservationArticle(2L);
+
+        Pageable pageable = PageRequest.of(0,2);
+        Pagination pagination = Pagination.builder()
+                .totalPage(1)
+                .pageable(pageable.getPageSize())
+                .isEnd(true)
+                .build();
+
+        FindAllReservationArticleResponse findAllReservationArticleResponse1 = FindAllReservationArticleResponse.of(member, article1 ,1L);
+        FindAllReservationArticleResponse findAllReservationArticleResponse2 = FindAllReservationArticleResponse.of(member, article2 ,0L);
+
+        List<FindAllReservationArticleResponse> responsePages = List.of(findAllReservationArticleResponse1, findAllReservationArticleResponse2);
+
+        PageResponse<FindAllReservationArticleResponse> response = PageResponse.of(pagination, responsePages);
+
+        doReturn(response)
+                .when(reservationArticleService)
+                .findAllReservationArticle(any(Pageable.class));
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/coffeechat/posts")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().is(RESERVATION_ARTICLE_ALL_FOUND.getStatus().value()))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(RESERVATION_ARTICLE_ALL_FOUND.getCode()))
+                .andExpect(jsonPath("$.msg").value(RESERVATION_ARTICLE_ALL_FOUND.getMsg()))
+                .andExpect(jsonPath("$.data.pagination.total_page").value(1))
+                .andExpect(jsonPath("$.data.pagination.pageable").value(pageable.getPageSize()))
+                .andExpect(jsonPath("$.data.pagination.is_end").value(true));
+
+
+        // Verify
+        verify(reservationArticleService, times(1)).findAllReservationArticle(any(PageRequest.class));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("예약게시글 조회 성공시 200 OK 와 응답 메시지를 반환한다.")
+    void testFindReservationArticle() throws Exception {
+        // Given
+        level = createTestLevel();
+        member = createTestMember();
+        ReservationArticle reservationArticle1 = createTestReservationArticle(1L);
+
+        ReservationDto reservationDto1 = ReservationDto.builder()
+                .finished(true)
+                .startTime(LocalDateTime.now())
+                .memberNickname("tester22")
+                .memberImageUrl("url")
+                .build();
+
+        ReservationDto reservationDto2 = ReservationDto.builder()
+                .finished(true)
+                .startTime(LocalDateTime.now())
+                .memberNickname("tester23")
+                .memberImageUrl("url")
+                .build();
+
+        List<ReservationDto> reservationDtoList = List.of(reservationDto1, reservationDto2);
+
+        FindReservationArticleResponse findReservationArticleResponse = FindReservationArticleResponse.of(member, reservationArticle1, reservationDtoList, level);
+
+        given(reservationArticleService.findReservationArticle(anyLong())).willReturn(findReservationArticleResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/coffeechat/posts/" + reservationArticle1.getId())
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().is(RESERVATION_ARTICLE_FOUND.getStatus().value()))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(RESERVATION_ARTICLE_FOUND.getCode()))
+                .andExpect(jsonPath("$.msg").value(RESERVATION_ARTICLE_FOUND.getMsg()));
+
+        // Verify
+        verify(reservationArticleService, times(1)).findReservationArticle(anyLong());
+
+    }
+
+
 }

--- a/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
@@ -12,7 +12,6 @@ import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservati
 import com.kernel360.kernelsquare.domain.reservation_article.dto.FindAllReservationArticleResponse;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.FindReservationArticleResponse;
 import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
-import com.kernel360.kernelsquare.domain.reservation_article.repository.ReservationArticleRepository;
 import com.kernel360.kernelsquare.domain.reservation_article.service.ReservationArticleService;
 import com.kernel360.kernelsquare.global.dto.PageResponse;
 import com.kernel360.kernelsquare.global.dto.Pagination;
@@ -171,7 +170,7 @@ class ReservationArticleControllerTest {
         // Given
         level = createTestLevel();
         member = createTestMember();
-        ReservationArticle reservationArticle1 = createTestReservationArticle(1L);
+        ReservationArticle reservationArticle = createTestReservationArticle(1L);
 
         ReservationDto reservationDto1 = ReservationDto.builder()
                 .finished(true)
@@ -189,12 +188,12 @@ class ReservationArticleControllerTest {
 
         List<ReservationDto> reservationDtoList = List.of(reservationDto1, reservationDto2);
 
-        FindReservationArticleResponse findReservationArticleResponse = FindReservationArticleResponse.of(member, reservationArticle1, reservationDtoList, level);
+        FindReservationArticleResponse findReservationArticleResponse = FindReservationArticleResponse.of(member, reservationArticle, reservationDtoList, level);
 
         given(reservationArticleService.findReservationArticle(anyLong())).willReturn(findReservationArticleResponse);
 
         // When & Then
-        mockMvc.perform(get("/api/v1/coffeechat/posts/" + reservationArticle1.getId())
+        mockMvc.perform(get("/api/v1/coffeechat/posts/" + reservationArticle.getId())
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleServiceTest.java
@@ -3,13 +3,16 @@ package com.kernel360.kernelsquare.domain.reservation_article.service;
 import com.kernel360.kernelsquare.domain.authority.entity.Authority;
 import com.kernel360.kernelsquare.domain.authority.repository.AuthorityRepository;
 import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
 import com.kernel360.kernelsquare.domain.member_authority.entity.MemberAuthority;
 import com.kernel360.kernelsquare.domain.member_authority.repository.MemberAuthorityRepository;
+import com.kernel360.kernelsquare.domain.reservation.repository.ReservationRepository;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleRequest;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.CreateReservationArticleResponse;
 import com.kernel360.kernelsquare.domain.reservation_article.dto.FindAllReservationArticleResponse;
+import com.kernel360.kernelsquare.domain.reservation_article.dto.FindReservationArticleResponse;
 import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
 import com.kernel360.kernelsquare.domain.reservation_article.repository.ReservationArticleRepository;
 import com.kernel360.kernelsquare.global.domain.AuthorityType;
@@ -28,6 +31,7 @@ import org.springframework.data.domain.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -45,19 +49,19 @@ class ReservationArticleServiceTest {
     @Mock
     private ReservationArticleRepository reservationArticleRepository;
     @Mock
+    private ReservationRepository reservationRepository;
+    @Mock
     private MemberRepository memberRepository;
-    @Mock
-    private MemberAuthorityRepository memberAuthorityRepository;
-    @Mock
-    private AuthorityRepository authorityRepository;
 
     private Member member;
     private Authority authority;
     private MemberAuthority memberRole;
+    private Level level;
 
     private ReservationArticle createTestReservationArticle(Long id) {
         return ReservationArticle.builder()
                 .id(id)
+                .member(member)
                 .title("testplz")
                 .content("ahahahahahhhh")
                 .hashTagList(List.of())
@@ -73,6 +77,14 @@ class ReservationArticleServiceTest {
                 .experience(10000L)
                 .introduction("hi, i'm hongjugwang.")
                 .imageUrl("s3:qwe12fasdawczx")
+                .level(level)
+                .build();
+    }
+
+    private Level createTestLevel() {
+        return Level.builder()
+                .name(6L)
+                .imageUrl("1.jpg")
                 .build();
     }
 
@@ -83,6 +95,12 @@ class ReservationArticleServiceTest {
                 .build();
     }
 
+    private Authority createTestAuthority() {
+        return Authority.builder()
+                .id(1L)
+                .authorityType(AuthorityType.ROLE_MENTOR)
+                .build();
+    }
     @Test
     @DisplayName("예약게시글 생성 테스트")
     void testCreateReservationArticle() {
@@ -115,17 +133,11 @@ class ReservationArticleServiceTest {
         verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
     }
 
-    private Authority createTestAuthority() {
-        return Authority.builder()
-                .id(1L)
-                .authorityType(AuthorityType.ROLE_MENTOR)
-                .build();
-    }
-
     @Test
     @DisplayName("모든 예약창 조회 테스트")
     void testFindAllReservationArticle() {
         // Given
+        level = createTestLevel();
         member = createTestMember();
         ReservationArticle reservationArticle1 = createTestReservationArticle(1L);
         ReservationArticle reservationArticle2 = createTestReservationArticle(2L);
@@ -134,8 +146,6 @@ class ReservationArticleServiceTest {
         Pageable pageable = PageRequest.of(0,2);
         Page<ReservationArticle> pages = new PageImpl<>(articles, pageable, articles.size());
 
-        given(reservationArticleRepository.findById(reservationArticle1.getId())).willReturn(Optional.of(reservationArticle1));
-        given(reservationArticleRepository.findById(reservationArticle2.getId())).willReturn(Optional.of(reservationArticle2));
         given(reservationArticleRepository.findAll(any(PageRequest.class))).willReturn(pages);
 
         Integer currentPage = pageable.getPageNumber() + 1;
@@ -156,6 +166,37 @@ class ReservationArticleServiceTest {
 
         // Verify
         verify(reservationArticleRepository, times(1)).findAll(any(PageRequest.class));
+    }
+
+
+    @Test
+    @DisplayName("예약창 조회 테스트")
+    void testFindReservationArticle() {
+        // Given
+        level = createTestLevel();
+        member = createTestMember();
+        ReservationArticle reservationArticle = createTestReservationArticle(1L);
+
+        given(reservationArticleRepository.findById(anyLong())).willReturn(Optional.ofNullable(reservationArticle));
+
+        // When
+        FindReservationArticleResponse findReservationArticleResponse = reservationArticleService.findReservationArticle(reservationArticle.getId());
+
+        // Then
+        assertThat(findReservationArticleResponse).isNotNull();
+        assertThat(findReservationArticleResponse.articleId()).isEqualTo(reservationArticle.getId());
+        assertThat(findReservationArticleResponse.title()).isEqualTo(reservationArticle.getTitle());
+        assertThat(findReservationArticleResponse.content()).isEqualTo(reservationArticle.getContent());
+        assertThat(findReservationArticleResponse.level()).isEqualTo(reservationArticle.getMember().getLevel().getName());
+        assertThat(findReservationArticleResponse.levelImageUrl()).isEqualTo("null/" + reservationArticle.getMember().getLevel().getImageUrl());
+        assertThat(findReservationArticleResponse.nickname()).isEqualTo(reservationArticle.getMember().getNickname());
+        assertThat(findReservationArticleResponse.memberId()).isEqualTo(reservationArticle.getMember().getId());
+        assertThat(findReservationArticleResponse.memberImageUrl()).isEqualTo("null/" + reservationArticle.getMember().getImageUrl());
+        assertThat(findReservationArticleResponse.hashTagList()).isEqualTo(reservationArticle.getHashTagList()
+                .stream().map(HashTag::getContent).toList());
+
+        // Verify
+        verify(reservationArticleRepository, times(1)).findById(anyLong());
     }
 
 }


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #84 

## 개요
> 커피챗 - 예약창 생성

## 상세 내용
- 모든 예약창 조회 기능 구현
- 예약창 상세 조회 기능 구현
- 테스트 코드 작성
- 예약내역 DTO
- 모든 예약창 응답에는 예약 남은 자리가 몇자리 남았는지 fullCheck 으로 전달
- FOUNDED, NOT FOUND, NOT PAGE 예외 응답코드 작성
