### PR TITLE
[fix] 예약창 전체조회, 상세조회 시 해시태그 응답값 버그 수정

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindAllReservationArticleResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindAllReservationArticleResponse.java
@@ -1,5 +1,6 @@
 package com.kernel360.kernelsquare.domain.reservation_article.dto;
 
+import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
 import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
@@ -33,7 +34,7 @@ public record FindAllReservationArticleResponse(
                 member.getLevel().getName(),
                 ImageUtils.makeImageUrl(member.getLevel().getImageUrl()),
                 article.getTitle(),
-                article.getHashTagList().stream().map(String::valueOf).toList(),
+                article.getHashTagList().stream().map(HashTag::getContent).toList(),
                 article.getCreatedDate(),
                 article.getModifiedDate(),
                 fullCheck

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindReservationArticleResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindReservationArticleResponse.java
@@ -1,5 +1,6 @@
 package com.kernel360.kernelsquare.domain.reservation_article.dto;
 
+import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
 import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
 import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
@@ -37,7 +38,7 @@ public record FindReservationArticleResponse(
                 ImageUtils.makeImageUrl(level.getImageUrl()),
                 article.getTitle(),
                 article.getContent(),
-                article.getHashTagList().stream().map(String::valueOf).toList(),
+                article.getHashTagList().stream().map(HashTag::getContent).toList(),
                 reservationDtos,
                 article.getCreatedDate(),
                 article.getModifiedDate()


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈

## 개요
> 예약창 전체조회, 상세조회 시 해시태그 응답값 버그 수정

## 상세 내용
- 해시태그가 주소값으로 나와 코드 수정하여 문자로 나오게 수정
