### PR TITLE
[bugfix] image_url 컬럼들 varchar(100)에서 varchar(200)으로 변경

### DIFF
--- a/src/main/resources/db/migration/V1.4__alter_table.sql
+++ b/src/main/resources/db/migration/V1.4__alter_table.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `answer`
+    MODIFY `image_url` VARCHAR(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+ALTER TABLE `answer_rank`
+    MODIFY `image_url` VARCHAR(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+ALTER TABLE `level`
+    MODIFY `image_url` VARCHAR(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+ALTER TABLE `member`
+    MODIFY `image_url` VARCHAR(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+ALTER TABLE `question`
+    MODIFY `image_url` VARCHAR(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL;


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #138 

## 개요
> image_url이 길어서 DB에 저장이 안되는 문제를 varchar 길이 제한을 늘려 해결하기 위함

## 상세 내용
- 기존 sql 파일을 수정하는 것이 아닌, flyway 버전 업을 통해 변경
- question, answer, member, answer_rank, level 테이블의 image_url 컬럼의 속성을 varchar(100)에서 varchar(200)으로 변경
