### PR TITLE
[feat] 해시태그 조회, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/controller/HashtagController.java
@@ -1,0 +1,36 @@
+package com.kernel360.kernelsquare.domain.hashtag.controller;
+
+import com.kernel360.kernelsquare.domain.hashtag.service.HashtagService;
+import com.kernel360.kernelsquare.domain.hashtag.dto.FindAllHashtagResponse;
+import com.kernel360.kernelsquare.global.common_response.ApiResponse;
+import com.kernel360.kernelsquare.global.common_response.ResponseEntityFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.kernel360.kernelsquare.global.common_response.response.code.HashTagResponseCode.HASHTAG_ALL_FOUND;
+import static com.kernel360.kernelsquare.global.common_response.response.code.HashTagResponseCode.HASHTAG_DELETED;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class HashtagController {
+    private final HashtagService hashtagService;
+
+    @GetMapping("/hashtags")
+    public ResponseEntity<ApiResponse<FindAllHashtagResponse>> findAllHashtag() {
+        FindAllHashtagResponse response = hashtagService.findAllHashtag();
+
+        return ResponseEntityFactory.toResponseEntity(HASHTAG_ALL_FOUND, response);
+    }
+
+    @DeleteMapping("/hashtags/{hashtagId}")
+    public ResponseEntity<ApiResponse> deleteHashtag(
+            @PathVariable
+            Long hashtagId
+    ) {
+        hashtagService.deleteHashtag(hashtagId);
+
+        return ResponseEntityFactory.toResponseEntity(HASHTAG_DELETED);
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/FindAllHashtagResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/FindAllHashtagResponse.java
@@ -5,9 +5,9 @@ import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
 import java.util.List;
 
 public record FindAllHashtagResponse(
-        List<Hashtag> hashtags
+        List<HashtagResponse> hashtags
 ) {
-    public static FindAllHashtagResponse from(List<Hashtag> hashtags) {
+    public static FindAllHashtagResponse from(List<HashtagResponse> hashtags) {
         return new FindAllHashtagResponse(hashtags);
     }
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/FindAllHashtagResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/FindAllHashtagResponse.java
@@ -1,0 +1,13 @@
+package com.kernel360.kernelsquare.domain.hashtag.dto;
+
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
+
+import java.util.List;
+
+public record FindAllHashtagResponse(
+        List<Hashtag> hashtags
+) {
+    public static FindAllHashtagResponse from(List<Hashtag> hashtags) {
+        return new FindAllHashtagResponse(hashtags);
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/FindAllHashtagResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/FindAllHashtagResponse.java
@@ -1,13 +1,11 @@
 package com.kernel360.kernelsquare.domain.hashtag.dto;
 
-import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
-
 import java.util.List;
 
 public record FindAllHashtagResponse(
-        List<HashtagResponse> hashtags
+        List<FindHashtagResponse> hashtags
 ) {
-    public static FindAllHashtagResponse from(List<HashtagResponse> hashtags) {
+    public static FindAllHashtagResponse from(List<FindHashtagResponse> hashtags) {
         return new FindAllHashtagResponse(hashtags);
     }
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/FindHashtagResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/FindHashtagResponse.java
@@ -5,12 +5,12 @@ import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
 /**
  * DTO for {@link com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag}
  */
-public record HashtagResponse(
+public record FindHashtagResponse(
         Long id,
         String content
 ) {
-    public static HashtagResponse from(Hashtag hashtag) {
-        return new HashtagResponse(
+    public static FindHashtagResponse from(Hashtag hashtag) {
+        return new FindHashtagResponse(
                 hashtag.getId(),
                 hashtag.getContent()
         );

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/HashtagResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/dto/HashtagResponse.java
@@ -1,0 +1,18 @@
+package com.kernel360.kernelsquare.domain.hashtag.dto;
+
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
+
+/**
+ * DTO for {@link com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag}
+ */
+public record HashtagResponse(
+        Long id,
+        String content
+) {
+    public static HashtagResponse from(Hashtag hashtag) {
+        return new HashtagResponse(
+                hashtag.getId(),
+                hashtag.getContent()
+        );
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/entity/Hashtag.java
@@ -1,5 +1,6 @@
 package com.kernel360.kernelsquare.domain.hashtag.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
 import com.kernel360.kernelsquare.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "hashtag")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class HashTag extends BaseEntity {
+public class Hashtag extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -20,12 +21,13 @@ public class HashTag extends BaseEntity {
     @Column(nullable = false ,name = "content", columnDefinition = "varchar(30)")
     private String content;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_article_id", columnDefinition = "bigint", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private ReservationArticle reservationArticle;
 
     @Builder
-    public HashTag(Long id, String content, ReservationArticle reservationArticle) {
+    public Hashtag(Long id, String content, ReservationArticle reservationArticle) {
         this.id = id;
         this.content = content;
         this.reservationArticle = reservationArticle;

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/entity/Hashtag.java
@@ -21,7 +21,6 @@ public class Hashtag extends BaseEntity {
     @Column(nullable = false ,name = "content", columnDefinition = "varchar(30)")
     private String content;
 
-    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_article_id", columnDefinition = "bigint", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private ReservationArticle reservationArticle;

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/repository/HashtagRepository.java
@@ -1,12 +1,12 @@
 package com.kernel360.kernelsquare.domain.hashtag.repository;
 
-import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface HashTagRepository extends JpaRepository<HashTag, Long> {
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     @Modifying
     @Query("DELETE FROM Hashtag a WHERE a.reservationArticle.id = :postId")
     void deleteAllByReservationArticleId(@Param("postId") Long postId);

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/service/HashtagService.java
@@ -1,0 +1,26 @@
+package com.kernel360.kernelsquare.domain.hashtag.service;
+
+import com.kernel360.kernelsquare.domain.hashtag.dto.FindAllHashtagResponse;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
+import com.kernel360.kernelsquare.domain.hashtag.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+
+    @Transactional(readOnly = true)
+    public FindAllHashtagResponse findAllHashtag() {
+        List<Hashtag> hashtagList = hashtagRepository.findAll();
+        return FindAllHashtagResponse.from(hashtagList);
+    }
+
+    @Transactional
+    public void deleteHashtag(Long hashtagId) { hashtagRepository.deleteById(hashtagId); }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/hashtag/service/HashtagService.java
@@ -1,12 +1,14 @@
 package com.kernel360.kernelsquare.domain.hashtag.service;
 
 import com.kernel360.kernelsquare.domain.hashtag.dto.FindAllHashtagResponse;
+import com.kernel360.kernelsquare.domain.hashtag.dto.FindHashtagResponse;
 import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
 import com.kernel360.kernelsquare.domain.hashtag.repository.HashtagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,8 +19,14 @@ public class HashtagService {
 
     @Transactional(readOnly = true)
     public FindAllHashtagResponse findAllHashtag() {
+
+        List<FindHashtagResponse> result = new ArrayList<>();
+
         List<Hashtag> hashtagList = hashtagRepository.findAll();
-        return FindAllHashtagResponse.from(hashtagList);
+        for (Hashtag hashtag : hashtagList) {
+            result.add(FindHashtagResponse.from(hashtag));
+        }
+        return FindAllHashtagResponse.from(result);
     }
 
     @Transactional

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindAllReservationArticleResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindAllReservationArticleResponse.java
@@ -1,6 +1,6 @@
 package com.kernel360.kernelsquare.domain.reservation_article.dto;
 
-import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
 import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.reservation_article.entity.ReservationArticle;
@@ -34,7 +34,7 @@ public record FindAllReservationArticleResponse(
                 member.getLevel().getName(),
                 ImageUtils.makeImageUrl(member.getLevel().getImageUrl()),
                 article.getTitle(),
-                article.getHashTagList().stream().map(HashTag::getContent).toList(),
+                article.getHashtagList().stream().map(Hashtag::getContent).toList(),
                 article.getCreatedDate(),
                 article.getModifiedDate(),
                 fullCheck

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindReservationArticleResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/dto/FindReservationArticleResponse.java
@@ -1,6 +1,6 @@
 package com.kernel360.kernelsquare.domain.reservation_article.dto;
 
-import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
 import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
 import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
@@ -38,7 +38,7 @@ public record FindReservationArticleResponse(
                 ImageUtils.makeImageUrl(level.getImageUrl()),
                 article.getTitle(),
                 article.getContent(),
-                article.getHashTagList().stream().map(HashTag::getContent).toList(),
+                article.getHashtagList().stream().map(Hashtag::getContent).toList(),
                 reservationDtos,
                 article.getCreatedDate(),
                 article.getModifiedDate()

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/entity/ReservationArticle.java
@@ -1,6 +1,6 @@
 package com.kernel360.kernelsquare.domain.reservation_article.entity;
 
-import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -29,20 +29,20 @@ public class ReservationArticle extends BaseEntity {
     private String content;
 
     @OneToMany(mappedBy = "reservationArticle")
-    private List<HashTag> hashTagList;
+    private List<Hashtag> hashtagList;
 
     @Builder
-    public ReservationArticle(Long id, Member member, String title, String content, List<HashTag> hashTagList) {
+    public ReservationArticle(Long id, Member member, String title, String content, List<Hashtag> hashtagList) {
         this.id = id;
         this.member = member;
         this.title = title;
         this.content = content;
-        this.hashTagList = hashTagList;
+        this.hashtagList = hashtagList;
     }
 
-    public void update(String title, String content, List<HashTag> hashTagList) {
+    public void update(String title, String content, List<Hashtag> hashtagList) {
         this.title = title;
         this.content = content;
-        this.hashTagList = hashTagList;
+        this.hashtagList = hashtagList;
     }
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleService.java
@@ -2,8 +2,8 @@ package com.kernel360.kernelsquare.domain.reservation_article.service;
 
 import com.kernel360.kernelsquare.domain.coffeechat.entity.ChatRoom;
 import com.kernel360.kernelsquare.domain.coffeechat.repository.CoffeeChatRepository;
-import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
-import com.kernel360.kernelsquare.domain.hashtag.repository.HashTagRepository;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
+import com.kernel360.kernelsquare.domain.hashtag.repository.HashtagRepository;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
 import com.kernel360.kernelsquare.domain.reservation.dto.ReservationDto;
@@ -38,7 +38,7 @@ public class ReservationArticleService {
     private final ReservationArticleRepository reservationArticleRepository;
     private final ReservationRepository reservationRepository;
     private final CoffeeChatRepository coffeeChatRepository;
-    private final HashTagRepository hashTagRepository;
+    private final HashtagRepository hashTagRepository;
 
     @Transactional
     public CreateReservationArticleResponse createReservationArticle(CreateReservationArticleRequest createReservationArticleRequest) {
@@ -50,7 +50,7 @@ public class ReservationArticleService {
 
         // HashTag 저장
         for (String hashTags : createReservationArticleRequest.hashTags()) {
-            HashTag hashTag = HashTag.builder()
+            Hashtag hashTag = Hashtag.builder()
                     .content(hashTags)
                     .reservationArticle(saveReservationArticle)
                     .build();

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/HashTagResponseCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/HashTagResponseCode.java
@@ -1,0 +1,31 @@
+package com.kernel360.kernelsquare.global.common_response.response.code;
+
+import com.kernel360.kernelsquare.global.common_response.service.code.HashTagServiceStatus;
+import com.kernel360.kernelsquare.global.common_response.service.code.ServiceStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum HashTagResponseCode implements ResponseCode{
+    HASHTAG_ALL_FOUND(HttpStatus.OK, HashTagServiceStatus.HASHTAG_ALL_FOUND, "모든 해시태그를 조회했습니다."),
+    HASHTAG_DELETED(HttpStatus.OK, HashTagServiceStatus.HASHTAG_DELETED, "해시태그를 삭제했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final ServiceStatus serviceStatus;
+    private final String msg;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public Integer getCode() {
+        return serviceStatus.getServiceStatus();
+    }
+
+    @Override
+    public String getMsg() {
+        return msg;
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/HashTagServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/HashTagServiceStatus.java
@@ -1,0 +1,19 @@
+package com.kernel360.kernelsquare.global.common_response.service.code;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum HashTagServiceStatus implements ServiceStatus {
+    //error
+    HASHTAG_NOT_FOUND(3301),
+
+    //success
+    HASHTAG_ALL_FOUND(3340),
+    HASHTAG_DELETED(3341);
+
+    private final Integer code;
+
+    @Override
+    public Integer getServiceStatus() { return code; }
+
+}

--- a/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
@@ -28,103 +28,105 @@ public class SecurityConfig {
     private final JWTAccessDeniedHandler jwtAccessDeniedHandler;
 
     private final String[] permitAllPatterns = new String[]{
-        "/api/v1/auth/check/email",
-        "/api/v1/auth/check/nickname",
-        "/api/v1/auth/signup",
-        "/api/v1/auth/login",
-        "/actuator",
-        "/actuator/**",
+            "/api/v1/auth/check/email",
+            "/api/v1/auth/check/nickname",
+            "/api/v1/auth/signup",
+            "/api/v1/auth/login",
+            "/actuator",
+            "/actuator/**",
 
-		// 소켓 통신의 임시 화면을 사용하기 위해 관련 경로는 permitAll
-		"/screen/**",
-		"/kernel-square/**",
-		"/topic/chat/room",
-		"/app/chat/message",
-		"/webjars/**",
-	};
+            // 소켓 통신의 임시 화면을 사용하기 위해 관련 경로는 permitAll
+            "/screen/**",
+            "/kernel-square/**",
+            "/topic/chat/room",
+            "/app/chat/message",
+            "/webjars/**",
+    };
 
-	private final String[] hasAnyAuthorityPatterns = new String[] {
-		"/api/v1/images"
-	};
+    private final String[] hasAnyAuthorityPatterns = new String[]{
+            "/api/v1/images"
+    };
 
-	private final String[] hasRoleUserPatterns = new String[] {
-		"/api/v1/auth/reissue",
-		"/api/v1/auth/logout",
-		"/api/v1/questions/answers/{answerId}",
-		"/api/v1/questions/{questionId}/answers",
-		"/api/v1/questions/answers/{answerId}/vote"
-	};
+    private final String[] hasRoleUserPatterns = new String[]{
+            "/api/v1/auth/reissue",
+            "/api/v1/auth/logout",
+            "/api/v1/questions/answers/{answerId}",
+            "/api/v1/questions/{questionId}/answers",
+            "/api/v1/questions/answers/{answerId}/vote"
+    };
 
-	private final String[] hasRoleAdminPatterns = new String[] {
-		"/api/v1/techs/{techStackId}",
-		"/api/v1/levels/**"
-	};
+    private final String[] hasRoleAdminPatterns = new String[]{
+            "/api/v1/techs/{techStackId}",
+            "/api/v1/levels/**"
+    };
 
-	@Bean
-	public PasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder();
-	}
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
-	//todo : filter 설정 추가하기
-	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http.csrf(httpSecurityCsrfConfigurer -> httpSecurityCsrfConfigurer.disable());
-		http.authorizeHttpRequests(authz -> authz
-			// 모든 접근 허용
-			.requestMatchers(permitAllPatterns).permitAll()
-			.requestMatchers(HttpMethod.GET, "/api/v1/questions/{questionId}").permitAll()
-			.requestMatchers(HttpMethod.GET, "/api/v1/questions").permitAll()
-			.requestMatchers(HttpMethod.GET, "/api/v1/search/questions").permitAll()
-			.requestMatchers(HttpMethod.GET, "/api/v1/questions/{questiondId}/answers").permitAll()
-			.requestMatchers(HttpMethod.GET, "/api/v1/levels").permitAll()
-			.requestMatchers(HttpMethod.GET, "/api/v1/coffeechat/posts").permitAll()
-			.requestMatchers(HttpMethod.GET, "/api/v1/coffeechat/posts/{postId}").permitAll()
+    //todo : filter 설정 추가하기
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(httpSecurityCsrfConfigurer -> httpSecurityCsrfConfigurer.disable());
+        http.authorizeHttpRequests(authz -> authz
+                // 모든 접근 허용
+                .requestMatchers(permitAllPatterns).permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/questions/{questionId}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/questions").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/search/questions").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/questions/{questiondId}/answers").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/levels").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/coffeechat/posts").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/coffeechat/posts/{postId}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/hashtags").permitAll()
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/hashtags/{hashtagId}").permitAll()
 
-			// 모든 권한에 대한 접근 허용
-			.requestMatchers(hasAnyAuthorityPatterns).authenticated()
-			.requestMatchers(HttpMethod.GET, "/api/v1/members/{memberId}").authenticated()
-			.requestMatchers(HttpMethod.GET, "/api/v1/techs").authenticated()
+                // 모든 권한에 대한 접근 허용
+                .requestMatchers(hasAnyAuthorityPatterns).authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/v1/members/{memberId}").authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/v1/techs").authenticated()
 
-			// ROLE_USER 권한 필요
-			.requestMatchers(hasRoleUserPatterns).permitAll()
-			.requestMatchers(HttpMethod.DELETE, "/api/v1/members/{memberId}").hasRole("USER")
-			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}").hasRole("USER")
-			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/password").hasRole("USER")
-			.requestMatchers(HttpMethod.POST, "/api/v1/questions/**").hasRole("USER")
-			.requestMatchers(HttpMethod.PUT, "/api/v1/questions/{questionId}").hasRole("USER")
-			.requestMatchers(HttpMethod.DELETE, "/api/v1/questions/{questionId}").hasRole("USER")
-			.requestMatchers(HttpMethod.POST, "/api/v1/questions/{questionId}/answers").hasRole("USER")
+                // ROLE_USER 권한 필요
+                .requestMatchers(hasRoleUserPatterns).permitAll()
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/members/{memberId}").hasRole("USER")
+                .requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}").hasRole("USER")
+                .requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/password").hasRole("USER")
+                .requestMatchers(HttpMethod.POST, "/api/v1/questions/**").hasRole("USER")
+                .requestMatchers(HttpMethod.PUT, "/api/v1/questions/{questionId}").hasRole("USER")
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/questions/{questionId}").hasRole("USER")
+                .requestMatchers(HttpMethod.POST, "/api/v1/questions/{questionId}/answers").hasRole("USER")
 
-			// ROLE_MENTOR 권한 필요
-			.requestMatchers(HttpMethod.POST, "/api/v1/coffeechat/posts").hasRole("MENTOR")
-			.requestMatchers(HttpMethod.POST, "/api/v1/coffeechat/rooms").hasRole("MENTOR")
-			.requestMatchers(HttpMethod.POST, "/api/v1/coffeechat/rooms/enter").hasAnyRole("MENTOR", "USER")
-            .requestMatchers(HttpMethod.DELETE, "/api/v1/coffeechat/posts/{postId}").hasRole("MENTOR")
+                // ROLE_MENTOR 권한 필요
+                .requestMatchers(HttpMethod.POST, "/api/v1/coffeechat/posts").hasRole("MENTOR")
+                .requestMatchers(HttpMethod.POST, "/api/v1/coffeechat/rooms").hasRole("MENTOR")
+                .requestMatchers(HttpMethod.POST, "/api/v1/coffeechat/rooms/enter").hasAnyRole("MENTOR", "USER")
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/coffeechat/posts/{postId}").hasRole("MENTOR")
 
-			// ROLE_ADMIN 권한 필요
-			.requestMatchers(hasRoleAdminPatterns).hasRole("ADMIN")
-			.requestMatchers(HttpMethod.POST, "/api/v1/levels").hasRole("ADMIN")
-			.requestMatchers(HttpMethod.POST, "/api/v1/techs").hasRole("ADMIN")
-		);
+                // ROLE_ADMIN 권한 필요
+                .requestMatchers(hasRoleAdminPatterns).hasRole("ADMIN")
+                .requestMatchers(HttpMethod.POST, "/api/v1/levels").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.POST, "/api/v1/techs").hasRole("ADMIN")
+        );
 
-		http.addFilterBefore(new JWTSettingFilter(tokenProvider), BasicAuthenticationFilter.class);
+        http.addFilterBefore(new JWTSettingFilter(tokenProvider), BasicAuthenticationFilter.class);
 
-		http.exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer
-			.authenticationEntryPoint(jwtAuthenticationEntryPoint)
-			.accessDeniedHandler(jwtAccessDeniedHandler));
+        http.exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler));
 
-		http.sessionManagement(sessionManagementConfigurer ->
-			sessionManagementConfigurer
-				.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http.sessionManagement(sessionManagementConfigurer ->
+                sessionManagementConfigurer
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-		// http.oauth2Login(oAuth2LoginConfigurer ->
-		// 		oAuth2LoginConfigurer
-		// 			.successHandler(oAuth2LoginSuccessHandler)
-		// 			.failureHandler(oAuth2LoginFailureHandler)
-		// 			.userInfoEndpoint(userInfoEndpointConfigurer ->
-		// 				userInfoEndpointConfigurer.userService(customOAuth2MemberService)))
-		http.logout(Customizer.withDefaults());
+        // http.oauth2Login(oAuth2LoginConfigurer ->
+        // 		oAuth2LoginConfigurer
+        // 			.successHandler(oAuth2LoginSuccessHandler)
+        // 			.failureHandler(oAuth2LoginFailureHandler)
+        // 			.userInfoEndpoint(userInfoEndpointConfigurer ->
+        // 				userInfoEndpointConfigurer.userService(customOAuth2MemberService)))
+        http.logout(Customizer.withDefaults());
 
-		return http.build();
-	}
+        return http.build();
+    }
 }

--- a/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
@@ -80,7 +80,6 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/v1/coffeechat/posts").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/coffeechat/posts/{postId}").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/hashtags").permitAll()
-                .requestMatchers(HttpMethod.DELETE, "/api/v1/hashtags/{hashtagId}").permitAll()
 
                 // 모든 권한에 대한 접근 허용
                 .requestMatchers(hasAnyAuthorityPatterns).authenticated()
@@ -107,6 +106,7 @@ public class SecurityConfig {
                 .requestMatchers(hasRoleAdminPatterns).hasRole("ADMIN")
                 .requestMatchers(HttpMethod.POST, "/api/v1/levels").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.POST, "/api/v1/techs").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/hashtags/{hashtagId}").hasRole("ADMIN")
         );
 
         http.addFilterBefore(new JWTSettingFilter(tokenProvider), BasicAuthenticationFilter.class);

--- a/src/test/java/com/kernel360/kernelsquare/domain/hashtag/controller/HashtagControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/hashtag/controller/HashtagControllerTest.java
@@ -1,0 +1,89 @@
+package com.kernel360.kernelsquare.domain.hashtag.controller;
+
+import com.kernel360.kernelsquare.domain.hashtag.dto.FindAllHashtagResponse;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
+import com.kernel360.kernelsquare.domain.hashtag.service.HashtagService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.kernel360.kernelsquare.global.common_response.response.code.HashTagResponseCode.HASHTAG_ALL_FOUND;
+import static com.kernel360.kernelsquare.global.common_response.response.code.HashTagResponseCode.HASHTAG_DELETED;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("해시태그 컨트롤러 단위 테스트")
+@WithMockUser
+@WebMvcTest(HashtagController.class)
+class HashtagControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private HashtagService hashtagService;
+
+    @Test
+    @DisplayName("모든 해시태그 조회 성공시 200 OK와 응답 메시지를 반환한다.")
+    void testFindAllHashtag() throws Exception {
+        // Given
+        List<Hashtag> hashtagList = Arrays.asList(
+                Hashtag.builder().content("#김밥천국").build(),
+                Hashtag.builder().content("#라멘").build()
+        );
+        FindAllHashtagResponse response = FindAllHashtagResponse.from(hashtagList);
+
+        doReturn(response)
+                .when(hashtagService)
+                .findAllHashtag();
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/hashtags")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().is(HASHTAG_ALL_FOUND.getStatus().value()))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(HASHTAG_ALL_FOUND.getCode()))
+                .andExpect(jsonPath("$.msg").value(HASHTAG_ALL_FOUND.getMsg()));
+
+        // Then
+        verify(hashtagService, times(1)).findAllHashtag();
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("해시태그 삭제 성공시 200 OK 와 응답 메시지를 반환한다.")
+    void testDeleteHashtag() throws Exception {
+        // Given
+        Hashtag hashtag = Hashtag.builder().id(1L).content("#김밥천국").build();
+
+        doNothing()
+                .when(hashtagService)
+                .deleteHashtag(anyLong());
+
+        // When & Then
+        mockMvc.perform(delete("/api/v1/hashtags/" + hashtag.getId())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8"))
+        .andExpect(status().is(HASHTAG_DELETED.getStatus().value()))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value(HASHTAG_DELETED.getCode()))
+        .andExpect(jsonPath("$.msg").value(HASHTAG_DELETED.getMsg()));
+
+        // Verify
+        verify(hashtagService, times(1)).deleteHashtag(anyLong());
+    }
+}

--- a/src/test/java/com/kernel360/kernelsquare/domain/hashtag/controller/HashtagControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/hashtag/controller/HashtagControllerTest.java
@@ -1,8 +1,10 @@
 package com.kernel360.kernelsquare.domain.hashtag.controller;
 
 import com.kernel360.kernelsquare.domain.hashtag.dto.FindAllHashtagResponse;
+import com.kernel360.kernelsquare.domain.hashtag.dto.FindHashtagResponse;
 import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
 import com.kernel360.kernelsquare.domain.hashtag.service.HashtagService;
+import org.hibernate.annotations.processing.Find;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,13 +38,12 @@ class HashtagControllerTest {
     @DisplayName("모든 해시태그 조회 성공시 200 OK와 응답 메시지를 반환한다.")
     void testFindAllHashtag() throws Exception {
         // Given
-        List<Hashtag> hashtagList = Arrays.asList(
-                Hashtag.builder().content("#김밥천국").build(),
-                Hashtag.builder().content("#라멘").build()
-        );
-        FindAllHashtagResponse response = FindAllHashtagResponse.from(hashtagList);
+        FindHashtagResponse response1 = new FindHashtagResponse(1L, "#testtag");
+        FindHashtagResponse response2 = new FindHashtagResponse(2L, "#mentoring");
 
-        doReturn(response)
+        FindAllHashtagResponse allHashtagResponse = FindAllHashtagResponse.from(List.of(response1, response2));
+
+        doReturn(allHashtagResponse)
                 .when(hashtagService)
                 .findAllHashtag();
 

--- a/src/test/java/com/kernel360/kernelsquare/domain/hashtag/service/HashtagServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/hashtag/service/HashtagServiceTest.java
@@ -1,0 +1,66 @@
+package com.kernel360.kernelsquare.domain.hashtag.service;
+
+import com.kernel360.kernelsquare.domain.hashtag.dto.FindAllHashtagResponse;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
+import com.kernel360.kernelsquare.domain.hashtag.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@DisplayName("해시태그 서비스 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+    @InjectMocks
+    private HashtagService hashtagService;
+    @Mock
+    private HashtagRepository hashtagRepository;
+
+    @Test
+    @DisplayName("모든 해시태그 조회 테스트")
+    void testFindAllHashtag() {
+        // Given
+        List<Hashtag> expectedHashtags = Arrays.asList(
+                Hashtag.builder().content("#김밥천국").build(),
+                Hashtag.builder().content("#라멘").build()
+        );
+        given(hashtagRepository.findAll()).willReturn(expectedHashtags);
+
+        // When
+        FindAllHashtagResponse actualHashtags = hashtagService.findAllHashtag();
+
+        // Then
+        assertThat(actualHashtags.hashtags().get(0).getId()).isEqualTo(expectedHashtags.get(0).getId());
+        assertThat(actualHashtags.hashtags().get(1).getId()).isEqualTo(expectedHashtags.get(1).getId());
+        assertThat(actualHashtags.hashtags().get(0).getContent()).isEqualTo(expectedHashtags.get(0).getContent());
+        assertThat(actualHashtags.hashtags().get(1).getContent()).isEqualTo(expectedHashtags.get(1).getContent());
+
+        verify(hashtagRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("해시태그 삭제 테스트")
+    void testDeleteHashtag() {
+        // Given
+        Hashtag hashtag = Hashtag.builder().id(1L).content("#김밥천국").build();
+
+        doNothing().when(hashtagRepository).deleteById(hashtag.getId());
+
+        // When
+        hashtagService.deleteHashtag(hashtag.getId());
+
+        // Then
+        verify(hashtagRepository).deleteById(hashtag.getId());
+    }
+
+}

--- a/src/test/java/com/kernel360/kernelsquare/domain/hashtag/service/HashtagServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/hashtag/service/HashtagServiceTest.java
@@ -40,10 +40,10 @@ class HashtagServiceTest {
         FindAllHashtagResponse actualHashtags = hashtagService.findAllHashtag();
 
         // Then
-        assertThat(actualHashtags.hashtags().get(0).getId()).isEqualTo(expectedHashtags.get(0).getId());
-        assertThat(actualHashtags.hashtags().get(1).getId()).isEqualTo(expectedHashtags.get(1).getId());
-        assertThat(actualHashtags.hashtags().get(0).getContent()).isEqualTo(expectedHashtags.get(0).getContent());
-        assertThat(actualHashtags.hashtags().get(1).getContent()).isEqualTo(expectedHashtags.get(1).getContent());
+        assertThat(actualHashtags.hashtags().get(0).id()).isEqualTo(expectedHashtags.get(0).getId());
+        assertThat(actualHashtags.hashtags().get(1).id()).isEqualTo(expectedHashtags.get(1).getId());
+        assertThat(actualHashtags.hashtags().get(0).content()).isEqualTo(expectedHashtags.get(0).getContent());
+        assertThat(actualHashtags.hashtags().get(1).content()).isEqualTo(expectedHashtags.get(1).getContent());
 
         verify(hashtagRepository, times(1)).findAll();
     }

--- a/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/controller/ReservationArticleControllerTest.java
@@ -3,7 +3,7 @@ package com.kernel360.kernelsquare.domain.reservation_article.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
 import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.reservation.dto.ReservationDto;
@@ -57,7 +57,7 @@ class ReservationArticleControllerTest {
                 .id(id)
                 .title("testplz")
                 .content("ahahahahahhhh")
-                .hashTagList(List.of())
+                .hashtagList(List.of())
                 .build();
     }
 
@@ -92,7 +92,7 @@ class ReservationArticleControllerTest {
 
         CreateReservationArticleRequest createReservationArticleRequest =
                 new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(), reservationArticle.getContent(),
-                reservationArticle.getHashTagList().stream().map(HashTag::getContent).toList(), List.of(LocalDateTime.now(),LocalDateTime.now().plusDays(2)));
+                reservationArticle.getHashtagList().stream().map(Hashtag::getContent).toList(), List.of(LocalDateTime.now(),LocalDateTime.now().plusDays(2)));
 
         objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         objectMapper.registerModule(new JavaTimeModule());

--- a/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/reservation_article/service/ReservationArticleServiceTest.java
@@ -2,8 +2,8 @@ package com.kernel360.kernelsquare.domain.reservation_article.service;
 
 import com.kernel360.kernelsquare.domain.authority.entity.Authority;
 import com.kernel360.kernelsquare.domain.coffeechat.repository.CoffeeChatRepository;
-import com.kernel360.kernelsquare.domain.hashtag.entity.HashTag;
-import com.kernel360.kernelsquare.domain.hashtag.repository.HashTagRepository;
+import com.kernel360.kernelsquare.domain.hashtag.entity.Hashtag;
+import com.kernel360.kernelsquare.domain.hashtag.repository.HashtagRepository;
 import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
@@ -50,7 +50,7 @@ class ReservationArticleServiceTest {
     @Mock
     private CoffeeChatRepository coffeeChatRepository;
     @Mock
-    private HashTagRepository hashTagRepository;
+    private HashtagRepository hashTagRepository;
     @Mock
     private MemberRepository memberRepository;
 
@@ -65,7 +65,7 @@ class ReservationArticleServiceTest {
                 .member(member)
                 .title("testplz")
                 .content("ahahahahahhhh")
-                .hashTagList(List.of())
+                .hashtagList(List.of())
                 .build();
     }
 
@@ -118,7 +118,7 @@ class ReservationArticleServiceTest {
 
         CreateReservationArticleRequest createReservationArticleRequest =
                 new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(), reservationArticle.getContent(),
-                        reservationArticle.getHashTagList().stream().map(HashTag::getContent).toList(), List.of(LocalDateTime.now(),LocalDateTime.now().plusDays(2)));
+                        reservationArticle.getHashtagList().stream().map(Hashtag::getContent).toList(), List.of(LocalDateTime.now(),LocalDateTime.now().plusDays(2)));
 
         given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
         given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
@@ -195,8 +195,8 @@ class ReservationArticleServiceTest {
         assertThat(findReservationArticleResponse.memberId()).isEqualTo(reservationArticle.getMember().getId());
         assertThat(findReservationArticleResponse.memberImageUrl().length()).isGreaterThan(reservationArticle.getMember().getImageUrl().length());
         assertThat(findReservationArticleResponse.memberImageUrl()).endsWith(reservationArticle.getMember().getImageUrl());
-        assertThat(findReservationArticleResponse.hashTagList()).isEqualTo(reservationArticle.getHashTagList()
-                .stream().map(HashTag::getContent).toList());
+        assertThat(findReservationArticleResponse.hashTagList()).isEqualTo(reservationArticle.getHashtagList()
+                .stream().map(Hashtag::getContent).toList());
 
         // Verify
         verify(reservationArticleRepository, times(1)).findById(anyLong());


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #136 #137 #135 

## 개요
> 해시태그 조회와 삭제 기능 구현

## 상세 내용
- 해시태그 모든 조회 기능 구현
- 해시태그 삭제 기능 구현
- HashTag 로 되어있던 부분들 -> Hashtag 로 수정
- ~순환참조 방지를 위해 @JsonIgnore 달음~  -> 다시 지우고 DTO 로 Response 만들어서 순환참조 방지함
- 테스트 완료