### PR TITLE
[refactor] 질문 검색 응답 dto 변경

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/search/controller/SearchController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/search/controller/SearchController.java
@@ -1,10 +1,9 @@
     package com.kernel360.kernelsquare.domain.search.controller;
 
-    import com.kernel360.kernelsquare.domain.question.dto.FindQuestionResponse;
+    import com.kernel360.kernelsquare.domain.search.dto.SearchQuestionResponse;
     import com.kernel360.kernelsquare.domain.search.service.SearchService;
     import com.kernel360.kernelsquare.global.common_response.ApiResponse;
     import com.kernel360.kernelsquare.global.common_response.ResponseEntityFactory;
-    import com.kernel360.kernelsquare.global.dto.PageResponse;
     import lombok.RequiredArgsConstructor;
     import org.springframework.data.domain.Pageable;
     import org.springframework.data.web.PageableDefault;
@@ -23,13 +22,13 @@
         private final SearchService searchService;
 
         @GetMapping("/search/questions")
-        public ResponseEntity<ApiResponse<PageResponse<FindQuestionResponse>>> searchQuestions(
+        public ResponseEntity<ApiResponse<SearchQuestionResponse>> searchQuestions(
             @PageableDefault(page = 0, size = 5)
             Pageable pageable,
             @RequestParam
             String keyword
         ) {
-            PageResponse<FindQuestionResponse> searchResults = searchService.searchQuestions(pageable, keyword);
+            SearchQuestionResponse searchResults = searchService.searchQuestions(pageable, keyword);
             return ResponseEntityFactory.toResponseEntity(SEARCH_QUESTION_COMPLETED, searchResults);
         }
     }

--- a/src/main/java/com/kernel360/kernelsquare/domain/search/dto/SearchQuestionResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/search/dto/SearchQuestionResponse.java
@@ -1,0 +1,17 @@
+package com.kernel360.kernelsquare.domain.search.dto;
+
+import com.kernel360.kernelsquare.domain.question.dto.FindQuestionResponse;
+import com.kernel360.kernelsquare.global.dto.PageResponse;
+import com.kernel360.kernelsquare.global.dto.Pagination;
+
+import java.util.List;
+
+public record SearchQuestionResponse(
+    Long totalCount,
+    Pagination pagination,
+    List<FindQuestionResponse> questionList
+) {
+    public static SearchQuestionResponse of(Long totalCount, PageResponse<FindQuestionResponse> pageResponse) {
+        return new SearchQuestionResponse(totalCount, pageResponse.pagination(), pageResponse.list());
+    }
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/search/service/SearchService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/search/service/SearchService.java
@@ -2,6 +2,7 @@ package com.kernel360.kernelsquare.domain.search.service;
 
 import com.kernel360.kernelsquare.domain.question.dto.FindQuestionResponse;
 import com.kernel360.kernelsquare.domain.question.entity.Question;
+import com.kernel360.kernelsquare.domain.search.dto.SearchQuestionResponse;
 import com.kernel360.kernelsquare.domain.search.repository.SearchRepository;
 import com.kernel360.kernelsquare.global.common_response.error.code.QuestionErrorCode;
 import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
@@ -19,11 +20,13 @@ import java.util.List;
 public class SearchService {
     private final SearchRepository searchRepository;
 
-    public PageResponse<FindQuestionResponse> searchQuestions(Pageable pageable, String keyword) {
+    public SearchQuestionResponse searchQuestions(Pageable pageable, String keyword) {
 
         Integer currentPage = pageable.getPageNumber()+1;
 
         Page<Question> pages = searchRepository.searchQuestionsByKeyword(pageable, keyword);
+
+        Long totalCount = pages.getTotalElements();
 
         Integer totalPages = pages.getTotalPages();
 
@@ -35,10 +38,12 @@ public class SearchService {
 
         Pagination pagination = Pagination.toEntity(totalPages, pages.getSize(), currentPage.equals(totalPages));
 
-        List<FindQuestionResponse> responsePages = pages.getContent().stream()
+        List<FindQuestionResponse> pageQuestionList = pages.getContent().stream()
             .map(question -> FindQuestionResponse.of(question.getMember(), question, question.getMember().getLevel()))
             .toList();
 
-        return PageResponse.of(pagination, responsePages);
+        PageResponse<FindQuestionResponse> pageResponse = PageResponse.of(pagination, pageQuestionList);
+
+        return SearchQuestionResponse.of(totalCount, pageResponse);
     }
 }

--- a/src/test/java/com/kernel360/kernelsquare/domain/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/search/controller/SearchControllerTest.java
@@ -4,6 +4,7 @@ import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.question.dto.FindQuestionResponse;
 import com.kernel360.kernelsquare.domain.question.entity.Question;
+import com.kernel360.kernelsquare.domain.search.dto.SearchQuestionResponse;
 import com.kernel360.kernelsquare.domain.search.service.SearchService;
 import com.kernel360.kernelsquare.global.dto.PageResponse;
 import com.kernel360.kernelsquare.global.dto.Pagination;
@@ -98,7 +99,9 @@ class SearchControllerTest {
 
         List<FindQuestionResponse> responsePages = List.of(findQuestionResponse1, findQuestionResponse2);
 
-        PageResponse<FindQuestionResponse> response = PageResponse.of(pagination, responsePages);
+        PageResponse<FindQuestionResponse> pageQuestionList = PageResponse.of(pagination, responsePages);
+
+        SearchQuestionResponse response = SearchQuestionResponse.of(2L, pageQuestionList);
 
         doReturn(response)
             .when(searchService)

--- a/src/test/java/com/kernel360/kernelsquare/domain/search/service/SearchServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/search/service/SearchServiceTest.java
@@ -2,10 +2,9 @@ package com.kernel360.kernelsquare.domain.search.service;
 
 import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
-import com.kernel360.kernelsquare.domain.question.dto.FindQuestionResponse;
 import com.kernel360.kernelsquare.domain.question.entity.Question;
+import com.kernel360.kernelsquare.domain.search.dto.SearchQuestionResponse;
 import com.kernel360.kernelsquare.domain.search.repository.SearchRepository;
-import com.kernel360.kernelsquare.global.dto.PageResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -102,14 +101,14 @@ class SearchServiceTest {
         if (totalPages == 0) totalPages+=1;
 
         //when
-        PageResponse<FindQuestionResponse> pageResponse = searchService.searchQuestions(pageable, keyword);
+        SearchQuestionResponse searchResults = searchService.searchQuestions(pageable, keyword);
 
         //then
-        assertThat(pageResponse).isNotNull();
-        assertThat(pageResponse.pagination().totalPage()).isEqualTo(totalPages);
-        assertThat(pageResponse.pagination().pageable()).isEqualTo(pages.getSize());
-        assertThat(pageResponse.pagination().isEnd()).isEqualTo(currentPage.equals(totalPages));
-        assertThat(pageResponse.list()).isNotNull();
+        assertThat(searchResults).isNotNull();
+        assertThat(searchResults.pagination().totalPage()).isEqualTo(totalPages);
+        assertThat(searchResults.pagination().pageable()).isEqualTo(pages.getSize());
+        assertThat(searchResults.pagination().isEnd()).isEqualTo(currentPage.equals(totalPages));
+        assertThat(searchResults.questionList()).isNotNull();
 
         //verify
         verify(searchRepository, times(1)).searchQuestionsByKeyword(any(Pageable.class), anyString());


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #143 

## 개요
> 질문 목록 검색에서 검색된 총 질문 수도 포함해서 응답으로 보내주기 위함

## 상세 내용
- 검색된 질문의 총개수 totalCount 추가
- list -> question_list로 응답 값 변경
