### PR TITLE
[bugfix] 회원 이미지 수정시 정상적으로 이미지 URL 처리 로직 추가

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/member/service/MemberService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.kernel360.kernelsquare.domain.member.service;
 
+import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +23,7 @@ public class MemberService {
 	@Transactional
 	public void updateMember(Long id, UpdateMemberRequest updateMemberRequest) {
 		Member member = getMemberById(id);
-		member.updateImageUrl(updateMemberRequest.imageUrl(), updateMemberRequest.introduction());
+		member.updateImageUrl(ImageUtils.parseFilePath(updateMemberRequest.imageUrl()), updateMemberRequest.introduction());
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [ ] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #146 

## 개요
> 회원 이미지 변경할 때, 이미지 URL이 정상적으로 처리가 되지 않는 문제를 해결하기 위함

## 상세 내용
- memberService 파일에서 updateMemberRequest에서 받은 imageUrl을 처리하고 update를 하도록 수정
