### PR TITLE
[bugfix] 회원 정보 수정 API 분리

### DIFF
--- a/src/main/java/com/kernel360/kernelsquare/domain/member/controller/MemberController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.kernel360.kernelsquare.domain.member.controller;
 
 import static com.kernel360.kernelsquare.global.common_response.response.code.MemberResponseCode.*;
 
+import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberIntroductionRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kernel360.kernelsquare.domain.member.dto.FindMemberResponse;
-import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberRequest;
+import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberProfileRequest;
 import com.kernel360.kernelsquare.domain.member.service.MemberService;
 import com.kernel360.kernelsquare.global.common_response.ApiResponse;
 import com.kernel360.kernelsquare.global.common_response.ResponseEntityFactory;
@@ -25,12 +26,20 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 	private final MemberService memberService;
 
-	@PutMapping("/members/{memberId}")
-	public ResponseEntity<ApiResponse> updateMember(@PathVariable Long memberId,
-		@RequestBody UpdateMemberRequest updateMemberRequest) {
-		memberService.updateMember(memberId, updateMemberRequest);
-		return ResponseEntityFactory.toResponseEntity(MEMBER_INFO_UPDATED);
+	@PutMapping("/members/{memberId}/profile")
+	public ResponseEntity<ApiResponse> updateMemberProfile(@PathVariable Long memberId,
+		@RequestBody UpdateMemberProfileRequest updateMemberProfileRequest) {
+		memberService.updateMemberProfile(memberId, updateMemberProfileRequest);
+		return ResponseEntityFactory.toResponseEntity(MEMBER_PROFILE_UPDATED);
 	}
+
+	@PutMapping("/members/{memberId}/introduction")
+	public ResponseEntity<ApiResponse> updateMemberIntroduction(@PathVariable Long memberId,
+		@RequestBody UpdateMemberIntroductionRequest updateMemberIntroductionRequest) {
+		memberService.updateMemberIntroduction(memberId, updateMemberIntroductionRequest);
+		return ResponseEntityFactory.toResponseEntity(MEMBER_INTRODUCTION_UPDATED);
+	}
+
 
 	@PutMapping("/members/{memberId}/password")
 	public ResponseEntity<ApiResponse> updateMemberPassword(@PathVariable Long memberId,

--- a/src/main/java/com/kernel360/kernelsquare/domain/member/controller/MemberController.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.kernel360.kernelsquare.domain.member.controller;
 import static com.kernel360.kernelsquare.global.common_response.response.code.MemberResponseCode.*;
 
 import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberIntroductionRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,7 +36,7 @@ public class MemberController {
 
 	@PutMapping("/members/{memberId}/introduction")
 	public ResponseEntity<ApiResponse> updateMemberIntroduction(@PathVariable Long memberId,
-		@RequestBody UpdateMemberIntroductionRequest updateMemberIntroductionRequest) {
+		@Valid @RequestBody UpdateMemberIntroductionRequest updateMemberIntroductionRequest) {
 		memberService.updateMemberIntroduction(memberId, updateMemberIntroductionRequest);
 		return ResponseEntityFactory.toResponseEntity(MEMBER_INTRODUCTION_UPDATED);
 	}

--- a/src/main/java/com/kernel360/kernelsquare/domain/member/dto/FindMemberResponse.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/member/dto/FindMemberResponse.java
@@ -12,7 +12,6 @@ public record FindMemberResponse(
 	Long experience,
 	String introduction,
 	String imageUrl,
-
 	Long level
 ) {
 

--- a/src/main/java/com/kernel360/kernelsquare/domain/member/dto/UpdateMemberIntroductionRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/member/dto/UpdateMemberIntroductionRequest.java
@@ -1,10 +1,11 @@
 package com.kernel360.kernelsquare.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
-public record UpdateMemberRequest(
-	String imageUrl,
+public record UpdateMemberIntroductionRequest(
+	@NotBlank
 	String introduction
 ) {
 }

--- a/src/main/java/com/kernel360/kernelsquare/domain/member/dto/UpdateMemberProfileRequest.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/member/dto/UpdateMemberProfileRequest.java
@@ -1,0 +1,9 @@
+package com.kernel360.kernelsquare.domain.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateMemberProfileRequest(
+	String imageUrl
+) {
+}

--- a/src/main/java/com/kernel360/kernelsquare/domain/member/entity/Member.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/member/entity/Member.java
@@ -49,9 +49,12 @@ public class Member extends BaseEntity {
 	@OneToMany(mappedBy = "member")
 	private List<MemberAuthority> authorities = new ArrayList<>();
 
-	public void updateImageUrl(String imageUrl, String introduction) {
-		this.imageUrl = imageUrl;
+	public void updateIntroduction(String introduction) {
 		this.introduction = introduction;
+	}
+
+	public void updateImageUrl(String imageUrl) {
+		this.imageUrl = imageUrl;
 	}
 
 	public void updatePassword(String password) {

--- a/src/main/java/com/kernel360/kernelsquare/domain/member/service/MemberService.java
+++ b/src/main/java/com/kernel360/kernelsquare/domain/member/service/MemberService.java
@@ -1,12 +1,13 @@
 package com.kernel360.kernelsquare.domain.member.service;
 
 import com.kernel360.kernelsquare.domain.image.utils.ImageUtils;
+import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberIntroductionRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kernel360.kernelsquare.domain.member.dto.FindMemberResponse;
-import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberRequest;
+import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberProfileRequest;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
 import com.kernel360.kernelsquare.global.common_response.error.code.MemberErrorCode;
@@ -21,9 +22,15 @@ public class MemberService {
 	private final PasswordEncoder passwordEncoder;
 
 	@Transactional
-	public void updateMember(Long id, UpdateMemberRequest updateMemberRequest) {
+	public void updateMemberIntroduction(Long id, UpdateMemberIntroductionRequest updateMemberIntroductionRequest) {
 		Member member = getMemberById(id);
-		member.updateImageUrl(ImageUtils.parseFilePath(updateMemberRequest.imageUrl()), updateMemberRequest.introduction());
+		member.updateIntroduction(updateMemberIntroductionRequest.introduction());
+	}
+
+	@Transactional
+	public void updateMemberProfile(Long id, UpdateMemberProfileRequest updateMemberProfileRequest) {
+		Member member = getMemberById(id);
+		member.updateImageUrl(ImageUtils.parseFilePath(updateMemberProfileRequest.imageUrl()));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/MemberResponseCode.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/response/code/MemberResponseCode.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 public enum MemberResponseCode implements ResponseCode {
 	MEMBER_FOUND(HttpStatus.OK, MemberServiceStatus.MEMBER_FOUND, "회원 정보 조회 성공"),
 	MEMBER_PASSWORD_UPDATED(HttpStatus.OK, MemberServiceStatus.MEMBER_PASSWORD_UPDATED, "비밀번호 수정 성공"),
-	MEMBER_INFO_UPDATED(HttpStatus.OK, MemberServiceStatus.MEMBER_INFO_UPDATED, "회원 정보 수정 성공"),
+	MEMBER_PROFILE_UPDATED(HttpStatus.OK, MemberServiceStatus.MEMBER_PROFILE_UPDATED, "회원 프로필 수정 성공"),
+	MEMBER_INTRODUCTION_UPDATED(HttpStatus.OK, MemberServiceStatus.MEMBER_INTRODUCTION_UPDATED, "회원 소개 수정 성공"),
 	MEMBER_DELETED(HttpStatus.OK, MemberServiceStatus.MEMBER_DELETED, "회원 탈퇴 성공");
 
 	private final HttpStatus code;

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/AnswerServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/AnswerServiceStatus.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum AnswerServiceStatus implements ServiceStatus{
+    //error
     ANSWER_CREATION_NOT_AUTHORIZED(2200),
     ANSWER_UPDATE_NOT_AUTHORIZED(2201),
     ANSWER_NOT_FOUND(2202),
 
+    //success
     ANSWER_CREATED(2240),
     ANSWERS_ALL_FOUND(2241),
     ANSWER_UPDATED(2242),

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/AuthorityServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/AuthorityServiceStatus.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum AuthorityServiceStatus implements ServiceStatus {
+	//error
 	AUTHORITY_NOT_FOUND(1500);
 
 	private final Integer code;

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/CommonServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/CommonServiceStatus.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum CommonServiceStatus implements ServiceStatus {
+	//error
 	DUPLICATE_DATA_EXIST(9000),
 	VALIDATION_CHECK_FAIL(9001);
 

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/MemberAnswerVoteStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/MemberAnswerVoteStatus.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum MemberAnswerVoteStatus implements ServiceStatus{
+    //error
     MEMBER_ANSWER_VOTE_NOT_FOUND(2202),
     MEMBER_ANSWER_VOTE_CREATED(2244),
     MEMBER_ANSWER_VOTE_DELETED(2245);

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/MemberServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/MemberServiceStatus.java
@@ -4,11 +4,15 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum MemberServiceStatus implements ServiceStatus {
+	//error
 	MEMBER_NOT_FOUND(1201),
+
+	//success
 	MEMBER_FOUND(1240),
 	MEMBER_PASSWORD_UPDATED(1241),
-	MEMBER_INFO_UPDATED(1242),
-	MEMBER_DELETED(1243);
+	MEMBER_INTRODUCTION_UPDATED(1242),
+	MEMBER_PROFILE_UPDATED(1243),
+	MEMBER_DELETED(1244);
 
 	private final Integer code;
 

--- a/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/TokenServiceStatus.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/common_response/service/code/TokenServiceStatus.java
@@ -4,12 +4,12 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum TokenServiceStatus implements ServiceStatus {
+	//error
 	INVALID_TOKEN(1300),
 	EXPIRED_TOKEN(1301),
 	UNAUTHORIZED_TOKEN(1302),
 	WRONG_TOKEN(1303),
 	EXPIRED_LOGIN_INFO(1304),
-
 	TOKEN_PROCESSING_ERROR(1305);
 
 	private final Integer code;

--- a/src/main/java/com/kernel360/kernelsquare/global/config/CorsConfig.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/config/CorsConfig.java
@@ -16,7 +16,7 @@ public class CorsConfig implements WebMvcConfigurer {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-					.allowedOrigins("http://3.34.88.0:3000", "http://localhost:3000")
+					.allowedOrigins("http://localhost:3000", "https://kernelsquare.live")
 					.allowCredentials(true)
 					.allowedHeaders("*")
 					.allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")

--- a/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
+++ b/src/main/java/com/kernel360/kernelsquare/global/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
             "/api/v1/auth/logout",
             "/api/v1/questions/answers/{answerId}",
             "/api/v1/questions/{questionId}/answers",
-            "/api/v1/questions/answers/{answerId}/vote"
+            "/api/v1/questions/answers/{answerId}/vote",
     };
 
     private final String[] hasRoleAdminPatterns = new String[]{
@@ -89,8 +89,9 @@ public class SecurityConfig {
                 // ROLE_USER 권한 필요
                 .requestMatchers(hasRoleUserPatterns).permitAll()
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/members/{memberId}").hasRole("USER")
-                .requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}").hasRole("USER")
+                .requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/profile").hasRole("USER")
                 .requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/password").hasRole("USER")
+                .requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/introduction").hasRole("USER")
                 .requestMatchers(HttpMethod.POST, "/api/v1/questions/**").hasRole("USER")
                 .requestMatchers(HttpMethod.PUT, "/api/v1/questions/{questionId}").hasRole("USER")
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/questions/{questionId}").hasRole("USER")

--- a/src/test/java/com/kernel360/kernelsquare/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/member/controller/MemberControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberIntroductionRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.dto.FindMemberResponse;
-import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberRequest;
+import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberProfileRequest;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member.service.MemberService;
 import com.kernel360.kernelsquare.global.common_response.error.exception.BusinessException;
@@ -55,35 +56,66 @@ public class MemberControllerTest {
 
 	@Test
 	@WithMockUser
-	@DisplayName("회원 정보 수정 성공 시, 200 OK와 메시지를 반환한다")
-	void testUpdateMember() throws Exception {
+	@DisplayName("회원 프로필 수정 성공 시, 200 OK와 메시지를 반환한다")
+	void testUpdateMemberProfile() throws Exception {
 		//given
 		String newImageUrl = "s3:dagwafd4323d1";
-		String newIntroduction = "bye, i'm hongjugwang.";
 
-		UpdateMemberRequest request = new UpdateMemberRequest(newImageUrl, newIntroduction);
+		UpdateMemberProfileRequest request = new UpdateMemberProfileRequest(newImageUrl);
 
 		doNothing()
 			.when(memberService)
-			.updateMember(anyLong(), any(UpdateMemberRequest.class));
+			.updateMemberProfile(anyLong(), any(UpdateMemberProfileRequest.class));
 
 		String jsonRequest = objectMapper.writeValueAsString(request);
 
 		//when & then
-		mockMvc.perform(put("/api/v1/members/" + testMemberId)
+		mockMvc.perform(put("/api/v1/members/" + testMemberId + "/profile")
 				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
 				.characterEncoding("UTF-8")
 				.content(jsonRequest))
-			.andExpect(status().is(MEMBER_INFO_UPDATED.getStatus().value()))
+			.andExpect(status().is(MEMBER_PROFILE_UPDATED.getStatus().value()))
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-			.andExpect(jsonPath("$.code").value(MEMBER_INFO_UPDATED.getCode()))
-			.andExpect(jsonPath("$.msg").value(MEMBER_INFO_UPDATED.getMsg()));
+			.andExpect(jsonPath("$.code").value(MEMBER_PROFILE_UPDATED.getCode()))
+			.andExpect(jsonPath("$.msg").value(MEMBER_PROFILE_UPDATED.getMsg()));
 
 		//verify
-		verify(memberService, times(1)).updateMember(anyLong(), any(UpdateMemberRequest.class));
+		verify(memberService, times(1)).updateMemberProfile(anyLong(), any(UpdateMemberProfileRequest.class));
 	}
+
+	@Test
+	@WithMockUser
+	@DisplayName("회원 소개 수정 성공 시, 200 OK와 메시지를 반환한다")
+	void testUpdateMemberIntroduction() throws Exception {
+		//given
+		String newIntroduction = "bye, i'm hongjugwang.";
+
+		UpdateMemberIntroductionRequest request = new UpdateMemberIntroductionRequest(newIntroduction);
+
+		doNothing()
+				.when(memberService)
+				.updateMemberIntroduction(anyLong(), any(UpdateMemberIntroductionRequest.class));
+
+		String jsonRequest = objectMapper.writeValueAsString(request);
+
+		//when & then
+		mockMvc.perform(put("/api/v1/members/" + testMemberId + "/introduction")
+						.with(csrf())
+						.contentType(MediaType.APPLICATION_JSON)
+						.accept(MediaType.APPLICATION_JSON)
+						.characterEncoding("UTF-8")
+						.content(jsonRequest))
+				.andExpect(status().is(MEMBER_INTRODUCTION_UPDATED.getStatus().value()))
+				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.code").value(MEMBER_INTRODUCTION_UPDATED.getCode()))
+				.andExpect(jsonPath("$.msg").value(MEMBER_INTRODUCTION_UPDATED.getMsg()));
+
+		//verify
+		verify(memberService, times(1)).updateMemberIntroduction(anyLong(), any(UpdateMemberIntroductionRequest.class));
+	}
+
 
 	@Test
 	@WithMockUser

--- a/src/test/java/com/kernel360/kernelsquare/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kernel360/kernelsquare/domain/member/service/MemberServiceTest.java
@@ -4,18 +4,19 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
+
+import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberIntroductionRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.kernel360.kernelsquare.domain.level.entity.Level;
 import com.kernel360.kernelsquare.domain.member.dto.FindMemberResponse;
-import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberRequest;
+import com.kernel360.kernelsquare.domain.member.dto.UpdateMemberProfileRequest;
 import com.kernel360.kernelsquare.domain.member.entity.Member;
 import com.kernel360.kernelsquare.domain.member.repository.MemberRepository;
 import com.kernel360.kernelsquare.global.common_response.error.code.MemberErrorCode;
@@ -32,18 +33,16 @@ public class MemberServiceTest {
 	private PasswordEncoder passwordEncoder;
 
 	@Test
-	@DisplayName("회원 정보 수정 테스트")
-	void testUpdateMember() throws Exception {
+	@DisplayName("회원 프로필 수정 테스트")
+	void testUpdateMemberProfile() throws Exception {
 		//given
 		Long testMemberId = 1L;
 
 		String newImageUrl = "s3:dagwafd4323d1";
-		String newIntroduction = "bye, i'm hongjugwang.";
 
-		UpdateMemberRequest updateMemberRequest = UpdateMemberRequest
+		UpdateMemberProfileRequest updateMemberProfileRequest = UpdateMemberProfileRequest
 			.builder()
 			.imageUrl(newImageUrl)
-			.introduction(newIntroduction)
 			.build();
 
 		Level level = Level.builder()
@@ -56,7 +55,6 @@ public class MemberServiceTest {
 		Member updatedMember = Member.builder()
 			.nickname(member.getNickname())
 			.imageUrl(newImageUrl)
-			.introduction(newIntroduction)
 			.level(level)
 			.email(member.getEmail())
 			.authorities(member.getAuthorities())
@@ -69,7 +67,7 @@ public class MemberServiceTest {
 			.findById(anyLong());
 
 		//when
-		memberService.updateMember(testMemberId, updateMemberRequest);
+		memberService.updateMemberProfile(testMemberId, updateMemberProfileRequest);
 
 		doReturn(optionalUpdatedMember)
 			.when(memberRepository)
@@ -79,6 +77,55 @@ public class MemberServiceTest {
 
 		//then
 		assertThat(optionalFoundMember.get().getImageUrl()).isEqualTo(newImageUrl);
+
+		//verify
+		verify(memberRepository, times(2)).findById(anyLong());
+	}
+
+	@Test
+	@DisplayName("회원 소개 수정 테스트")
+	void testUpdateMemberIntroduction() throws Exception {
+		//given
+		Long testMemberId = 1L;
+
+		String newIntroduction = "bye, i'm hongjugwang.";
+
+		UpdateMemberIntroductionRequest updateMemberIntroductionRequest = UpdateMemberIntroductionRequest
+				.builder()
+				.introduction(newIntroduction)
+				.build();
+
+		Level level = Level.builder()
+				.imageUrl("level 1")
+				.name(1L)
+				.build();
+
+		Member member = createTestMember();
+		Optional<Member> optionalMember = Optional.of(member);
+		Member updatedMember = Member.builder()
+				.nickname(member.getNickname())
+				.introduction(newIntroduction)
+				.level(level)
+				.email(member.getEmail())
+				.authorities(member.getAuthorities())
+				.password(member.getPassword())
+				.build();
+		Optional<Member> optionalUpdatedMember = Optional.of(updatedMember);
+
+		doReturn(optionalMember)
+				.when(memberRepository)
+				.findById(anyLong());
+
+		//when
+		memberService.updateMemberIntroduction(testMemberId, updateMemberIntroductionRequest);
+
+		doReturn(optionalUpdatedMember)
+				.when(memberRepository)
+				.findById(anyLong());
+
+		Optional<Member> optionalFoundMember = memberRepository.findById(testMemberId);
+
+		//then
 		assertThat(optionalFoundMember.get().getIntroduction()).isEqualTo(newIntroduction);
 
 		//verify


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #158 

## 개요
> 회원 소개 변경 시 프로필이 Null로 바뀌는 버그 수정
> API를 분리하여 관련 문제가 없도록 만듬
> 이슈에 관련된 설명

## 상세 내용
- 회원 정보 수정을 회원 프로필 수정과 회원 소개 수정으로 바꾸고 응답 상태 코드를 업데이트
- 소개변경 API : member/{memberId}/introduction
- 프로필변경 API : member/{memberId}/profile
  - API 명세서
    - https://www.notion.so/API-0dd89c67c2af4c2abedcc4712f8e627e
  - 응답상태코드
    - https://www.notion.so/c54aec9cd60e47078d0d321b0472ae09
