### PR TITLE
[bugfix] 채팅방 입장 응답에서 expirationTime에 @JsonFormat 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ logs/**
 !**/src/test/**/build/
 core/src/main/java/com/kernelsquare/core/compose/data/db/**
 core
+src/main/java/com/kernel360/kernelsquare/global/compose/mongo/**
 
 ### STS ###
 .apt_generated

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/coffeechat/dto/EnterCoffeeChatRoomResponse.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/coffeechat/dto/EnterCoffeeChatRoomResponse.java
@@ -1,5 +1,6 @@
 package com.kernelsquare.memberapi.domain.coffeechat.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.kernelsquare.domainmysql.domain.coffeechat.entity.ChatRoom;
 
 import lombok.Builder;
@@ -9,8 +10,12 @@ import java.time.LocalDateTime;
 @Builder
 public record EnterCoffeeChatRoomResponse(
 	String articleTitle,
+
 	String roomKey,
+
 	Boolean active,
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
 	LocalDateTime expirationTime
 ) {
 	public static EnterCoffeeChatRoomResponse of(String articleTitle, ChatRoom chatRoom) {


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #214 

## 개요
> 시간 관련 데이터는 Z를 붙여 보내기로 하여서 수정

## 상세 내용
- EnterCoffeeChatRoomResponse의 expirationTime에 @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") 추가
