### PR TITLE
[bugfix] MongoMessageType에서 빠져있는 CODE 추가

### DIFF
--- a/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/coffeechat/entity/MongoMessageType.java
+++ b/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/coffeechat/entity/MongoMessageType.java
@@ -4,5 +4,5 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum MongoMessageType {
-	ENTER, TALK, LEAVE, EXPIRE
+	ENTER, TALK, CODE, LEAVE, EXPIRE
 }


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [ ] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #216 

## 개요
> CODE 타입 메시지를 정상적으로 저장하고 sub에게 보낼 수 있도록 하기 위함

## 상세 내용
- MongoMessageType에 CODE 추가
