### PR TITLE
[bugfix] 예약창 상세보기에서 멤버 이미지 URL 깨지는 문제 해결

### DIFF
--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/dto/FindReservationResponse.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/dto/FindReservationResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.kernelsquare.domainmysql.domain.reservation.entity.Reservation;
 
+import com.kernelsquare.memberapi.domain.image.utils.ImageUtils;
 import lombok.Builder;
 
 @Builder
@@ -23,7 +24,7 @@ public record FindReservationResponse(
 
 		if (reservation.getMember() != null) {
 			nickname = reservation.getMember().getNickname();
-			imageUrl = reservation.getMember().getImageUrl();
+			imageUrl = ImageUtils.makeImageUrl(reservation.getMember().getImageUrl());
 		}
 
 		return new FindReservationResponse(


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #221 

## 개요
> 절대 URL로 보내야는데, 부분 URL로 보내고 있음을 확인했고, 수정하기 위함

## 상세 내용
- FindReservationResponse에서 imageUrl = reservation.getMember().getImageUrl(); -> imageUrl = ImageUtils.makeImageUrl(reservation.getMember().getImageUrl()); 로 수정하여 응답으로 절대 URL로 보내게 수정
