### PR TITLE
[hotfix] 회원가입, 로그인, 이메일 중복, 닉네임 중복 체크 시 유효성 검증 순서 및 한글 유효성 검증 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ logs/**
 !**/src/test/**/build/
 core/src/main/java/com/kernelsquare/core/compose/data/db/**
 src/main/java/com/kernel360/kernelsquare/global/compose/mongo/**
+member-api/logs/**
+admin-api/logs/**
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ core/src/main/java/com/kernelsquare/core/compose/data/db/**
 src/main/java/com/kernel360/kernelsquare/global/compose/mongo/**
 member-api/logs/**
 admin-api/logs/**
+member-api/member-api/logs/**
+admin-api/admin-api/logs/**
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ logs/**
 !**/src/main/**/build/
 !**/src/test/**/build/
 core/src/main/java/com/kernelsquare/core/compose/data/db/**
-core
 
 ### STS ###
 .apt_generated

--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/controller/AuthController.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.kernelsquare.adminapi.domain.auth.controller;
 import static com.kernelsquare.core.common_response.response.code.AuthResponseCode.*;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,9 +21,9 @@ import com.kernelsquare.adminapi.domain.auth.service.AuthService;
 import com.kernelsquare.adminapi.domain.auth.service.TokenProvider;
 import com.kernelsquare.core.common_response.ApiResponse;
 import com.kernelsquare.core.common_response.ResponseEntityFactory;
+import com.kernelsquare.core.validation.ValidationSequence;
 import com.kernelsquare.domainmysql.domain.member.entity.Member;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -33,7 +34,8 @@ public class AuthController {
 	private final TokenProvider tokenProvider;
 
 	@PostMapping("/auth/login")
-	public ResponseEntity<ApiResponse<LoginResponse>> login(final @RequestBody @Valid LoginRequest loginRequest) {
+	public ResponseEntity<ApiResponse<LoginResponse>> login(
+		final @RequestBody @Validated(ValidationSequence.class) LoginRequest loginRequest) {
 		Member member = authService.login(loginRequest);
 		TokenResponse tokenResponse = tokenProvider.createToken(member, loginRequest);
 		LoginResponse loginResponse = LoginResponse.of(member, tokenResponse);
@@ -41,7 +43,8 @@ public class AuthController {
 	}
 
 	@PostMapping("/auth/signup")
-	public ResponseEntity<ApiResponse<SignUpResponse>> signUp(final @RequestBody @Valid SignUpRequest signUpRequest) {
+	public ResponseEntity<ApiResponse<SignUpResponse>> signUp(
+		final @RequestBody @Validated(ValidationSequence.class) SignUpRequest signUpRequest) {
 		SignUpResponse signUpResponse = authService.signUp(signUpRequest);
 		return ResponseEntityFactory.toResponseEntity(SIGN_UP_SUCCESS, signUpResponse);
 	}
@@ -55,14 +58,14 @@ public class AuthController {
 
 	@PostMapping("/auth/check/email")
 	public ResponseEntity<ApiResponse> isEmailUnique(
-		final @Valid @RequestBody CheckDuplicateEmailRequest emailRequest) {
+		final @RequestBody @Validated(ValidationSequence.class) CheckDuplicateEmailRequest emailRequest) {
 		authService.isEmailUnique(emailRequest.email());
 		return ResponseEntityFactory.toResponseEntity(EMAIL_UNIQUE_VALIDATED);
 	}
 
 	@PostMapping("/auth/check/nickname")
 	public ResponseEntity<ApiResponse> isNicknameUnique(
-		final @Valid @RequestBody CheckDuplicateNicknameRequest nicknameRequest) {
+		final @RequestBody @Validated(ValidationSequence.class) CheckDuplicateNicknameRequest nicknameRequest) {
 		authService.isNicknameUnique(nicknameRequest.nickname());
 		return ResponseEntityFactory.toResponseEntity(NICKNAME_UNIQUE_VALIDATED);
 	}

--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/CheckDuplicateEmailRequest.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/CheckDuplicateEmailRequest.java
@@ -1,16 +1,20 @@
 package com.kernelsquare.adminapi.domain.auth.dto;
 
+import com.kernelsquare.core.validation.ValidationGroups;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record CheckDuplicateEmailRequest(
 
-	@NotBlank(message = "이메일을 입력해 주세요.")
-	@Email(message = "이메일 형식으로 입력해 주세요.")
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.")
+	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
+	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
 	String email
 ) {
 }

--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/CheckDuplicateEmailRequest.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/CheckDuplicateEmailRequest.java
@@ -1,6 +1,7 @@
 package com.kernelsquare.adminapi.domain.auth.dto;
 
 import com.kernelsquare.core.validation.ValidationGroups;
+import com.kernelsquare.core.validation.constants.AuthValidationConstants;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -11,10 +12,10 @@ import lombok.Builder;
 @Builder
 public record CheckDuplicateEmailRequest(
 
-	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
-	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
+	@NotBlank(message = AuthValidationConstants.EMAIL_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = AuthValidationConstants.EMAIL_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = AuthValidationConstants.EMAIL_PATTERN, groups = ValidationGroups.PatternGroup.class)
+	@Email(message = AuthValidationConstants.EMAIL, groups = ValidationGroups.EmailGroup.class)
 	String email
 ) {
 }

--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/CheckDuplicateNicknameRequest.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/CheckDuplicateNicknameRequest.java
@@ -1,13 +1,17 @@
 package com.kernelsquare.adminapi.domain.auth.dto;
 
+import com.kernelsquare.core.validation.ValidationGroups;
+
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record CheckDuplicateNicknameRequest(
-	@NotBlank(message = "닉네임을 입력해 주세요.")
-	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.")
+	@NotBlank(message = "닉네임을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "완전한 한글 조합 또는 영문 대소문자만 입력하세요.", groups = ValidationGroups.PatternGroup.class)
 	String nickname
 ) {
 }

--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/CheckDuplicateNicknameRequest.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/CheckDuplicateNicknameRequest.java
@@ -1,6 +1,7 @@
 package com.kernelsquare.adminapi.domain.auth.dto;
 
 import com.kernelsquare.core.validation.ValidationGroups;
+import com.kernelsquare.core.validation.constants.AuthValidationConstants;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -9,9 +10,9 @@ import lombok.Builder;
 
 @Builder
 public record CheckDuplicateNicknameRequest(
-	@NotBlank(message = "닉네임을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "완전한 한글 조합 또는 영문 대소문자만 입력하세요.", groups = ValidationGroups.PatternGroup.class)
+	@NotBlank(message = AuthValidationConstants.NICKNAME_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 2, max = 8, message = AuthValidationConstants.NICKNAME_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = AuthValidationConstants.NICKNAME_PATTERN, groups = ValidationGroups.PatternGroup.class)
 	String nickname
 ) {
 }

--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/LoginRequest.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/LoginRequest.java
@@ -1,6 +1,7 @@
 package com.kernelsquare.adminapi.domain.auth.dto;
 
 import com.kernelsquare.core.validation.ValidationGroups;
+import com.kernelsquare.core.validation.constants.AuthValidationConstants;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -10,16 +11,13 @@ import lombok.Builder;
 
 @Builder
 public record LoginRequest(
-	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
-	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
+	@NotBlank(message = AuthValidationConstants.EMAIL_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = AuthValidationConstants.EMAIL_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = AuthValidationConstants.EMAIL_PATTERN, groups = ValidationGroups.PatternGroup.class)
+	@Email(message = AuthValidationConstants.EMAIL, groups = ValidationGroups.EmailGroup.class)
 	String email,
 
-	@NotBlank(message = "비밀번호를 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
-		message = "영문 대소문자, 특수문자, 숫자를 각각 1자 이상 포함하세요.", groups = ValidationGroups.PatternGroup.class)
+	@NotBlank(message = AuthValidationConstants.PASSWORD_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
 	String password
 ) {
 }

--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/LoginRequest.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/LoginRequest.java
@@ -1,19 +1,25 @@
 package com.kernelsquare.adminapi.domain.auth.dto;
 
+import com.kernelsquare.core.validation.ValidationGroups;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record LoginRequest(
-	@NotBlank(message = "이메일을 입력해 주세요.")
-	@Email(message = "이메일 형식으로 입력해 주세요.")
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.")
+	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
+	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
 	String email,
 
-	@NotBlank(message = "비밀번호를 입력해 주세요.")
-	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.")
+	@NotBlank(message = "비밀번호를 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+		message = "영문 대소문자, 특수문자, 숫자를 각각 1자 이상 포함하세요.", groups = ValidationGroups.PatternGroup.class)
 	String password
 ) {
 }

--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/SignUpRequest.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/SignUpRequest.java
@@ -1,6 +1,7 @@
 package com.kernelsquare.adminapi.domain.auth.dto;
 
 import com.kernelsquare.core.validation.ValidationGroups;
+import com.kernelsquare.core.validation.constants.AuthValidationConstants;
 import com.kernelsquare.domainmysql.domain.level.entity.Level;
 import com.kernelsquare.domainmysql.domain.member.entity.Member;
 
@@ -12,21 +13,21 @@ import lombok.Builder;
 
 @Builder
 public record SignUpRequest(
-	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
-	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
+	@NotBlank(message = AuthValidationConstants.EMAIL_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = AuthValidationConstants.EMAIL_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = AuthValidationConstants.EMAIL_PATTERN, groups = ValidationGroups.PatternGroup.class)
+	@Email(message = AuthValidationConstants.EMAIL, groups = ValidationGroups.EmailGroup.class)
 	String email,
 
-	@NotBlank(message = "닉네임을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "완전한 한글 조합 또는 영문 대소문자만 입력하세요.", groups = ValidationGroups.PatternGroup.class)
+	@NotBlank(message = AuthValidationConstants.NICKNAME_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 2, max = 8, message = AuthValidationConstants.NICKNAME_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = AuthValidationConstants.NICKNAME_PATTERN, groups = ValidationGroups.PatternGroup.class)
 	String nickname,
 
-	@NotBlank(message = "비밀번호를 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@NotBlank(message = AuthValidationConstants.PASSWORD_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 8, max = 16, message = AuthValidationConstants.PASSWORD_SIZE, groups = ValidationGroups.SizeGroup.class)
 	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
-		message = "영문 대소문자, 특수문자, 숫자를 각각 1자 이상 포함하세요.", groups = ValidationGroups.PatternGroup.class)
+		message = AuthValidationConstants.PASSWORD_PATTERN, groups = ValidationGroups.PatternGroup.class)
 	String password
 ) {
 

--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/SignUpRequest.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/auth/dto/SignUpRequest.java
@@ -1,26 +1,32 @@
 package com.kernelsquare.adminapi.domain.auth.dto;
 
+import com.kernelsquare.core.validation.ValidationGroups;
 import com.kernelsquare.domainmysql.domain.level.entity.Level;
 import com.kernelsquare.domainmysql.domain.member.entity.Member;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record SignUpRequest(
-	@NotBlank(message = "이메일을 입력해 주세요.")
-	@Email(message = "이메일 형식으로 입력해 주세요.")
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.")
+	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
+	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
 	String email,
 
-	@NotBlank(message = "닉네임을 입력해 주세요.")
-	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.")
+	@NotBlank(message = "닉네임을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "완전한 한글 조합 또는 영문 대소문자만 입력하세요.", groups = ValidationGroups.PatternGroup.class)
 	String nickname,
 
-	@NotBlank(message = "비밀번호를 입력해 주세요.")
-	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.")
+	@NotBlank(message = "비밀번호를 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+		message = "영문 대소문자, 특수문자, 숫자를 각각 1자 이상 포함하세요.", groups = ValidationGroups.PatternGroup.class)
 	String password
 ) {
 
@@ -32,7 +38,7 @@ public record SignUpRequest(
 			.password(password)
 			.experience(0L)
 			.imageUrl(null)
-			.introduction(null)
+			.introduction("")
 			.level(level)
 			.build();
 	}

--- a/admin-api/src/test/java/com/kernelsquare/adminapi/domain/auth/controller/AuthControllerTest.java
+++ b/admin-api/src/test/java/com/kernelsquare/adminapi/domain/auth/controller/AuthControllerTest.java
@@ -132,7 +132,7 @@ public class AuthControllerTest {
 			.builder()
 			.nickname("woww")
 			.email("jugwang@naver.com")
-			.password("hashedPassword")
+			.password("hashedPassw@1d")
 			.build();
 
 		Member member = Member
@@ -140,7 +140,7 @@ public class AuthControllerTest {
 			.id(1L)
 			.nickname("woww")
 			.email("jugwang@naver.com")
-			.password("hashedPassword")
+			.password("hashedPassw@1")
 			.experience(10000L)
 			.introduction("hi, i'm hongjugwang.")
 			.imageUrl("s3:qwe12fasdawczx")

--- a/admin-api/src/test/java/com/kernelsquare/adminapi/domain/auth/dto/AuthRequestDtoTest.java
+++ b/admin-api/src/test/java/com/kernelsquare/adminapi/domain/auth/dto/AuthRequestDtoTest.java
@@ -3,10 +3,12 @@ package com.kernelsquare.adminapi.domain.auth.dto;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import com.kernelsquare.core.validation.ValidationSequence;
+import com.kernelsquare.core.validation.constants.AuthValidationConstants;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -15,101 +17,128 @@ import jakarta.validation.ValidatorFactory;
 
 @DisplayName("Auth 도메인 요청 Dto 종합 테스트")
 class AuthRequestDtoTest {
-	ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-	Validator validator = factory.getValidator();
+	private final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+	private final Validator validator = factory.getValidator();
 
 	@Test
-	@DisplayName("이메일 중복 체크 검증 테스트")
-	void validateCheckDuplicateEmailRequest() {
-		CheckDuplicateEmailRequest checkDuplicateEmailRequest1 = CheckDuplicateEmailRequest.builder()
+	@DisplayName("유효한 회원가입 요청에 대한 테스트")
+	void validSignUpRequest() {
+		// given
+		SignUpRequest signUpRequest = SignUpRequest.builder()
+			.email("valid@example.com")
+			.nickname("validNi")
+			.password("lid@Pad123")
+			.build();
+
+		// when
+		Set<ConstraintViolation<SignUpRequest>> violations = validator.validate(signUpRequest,
+			ValidationSequence.class);
+
+		// then
+		assertThat(violations).isEmpty();
+	}
+
+	@Test
+	@DisplayName("닉네임이 유효하지 않은 경우의 테스트")
+	void invalidNickname() {
+		// given
+		SignUpRequest signUpRequest = SignUpRequest.builder()
+			.email("valid@example.com")
+			.nickname("invalidNickname1")
+			.password("Valid@Password123")
+			.build();
+
+		// when
+		Set<ConstraintViolation<SignUpRequest>> violations = validator.validate(signUpRequest,
+			ValidationSequence.class);
+
+		// then
+		assertThat(violations).hasSize(2);
+		assertThat(violations).extracting("message").contains(AuthValidationConstants.NICKNAME_SIZE);
+	}
+
+	@Test
+	@DisplayName("비밀번호가 유효하지 않은 경우의 테스트")
+	void invalidPassword() {
+		// given
+		SignUpRequest signUpRequest = SignUpRequest.builder()
+			.email("valid@example.com")
+			.nickname("validNickname")
+			.password("invalidpassword")
+			.build();
+
+		// when
+		Set<ConstraintViolation<SignUpRequest>> violations = validator.validate(signUpRequest,
+			ValidationSequence.class);
+
+		// then
+		assertThat(violations).hasSize(1);
+		assertThat(violations).extracting("message").contains(AuthValidationConstants.NICKNAME_SIZE);
+	}
+
+	@Test
+	@DisplayName("이메일 주소가 빈 문자열일 때의 테스트")
+	void blankEmail() {
+		// given
+		CheckDuplicateEmailRequest request = CheckDuplicateEmailRequest.builder()
 			.email("")
 			.build();
 
-		CheckDuplicateEmailRequest checkDuplicateEmailRequest2 = CheckDuplicateEmailRequest.builder()
-			.email("asdsaas")
-			.build();
+		// when
+		Set<ConstraintViolation<CheckDuplicateEmailRequest>> violations = validator.validate(request,
+			ValidationSequence.class);
 
-		Set<ConstraintViolation<CheckDuplicateEmailRequest>> violations1 = validator.validate(
-			checkDuplicateEmailRequest1);
-		Set<String> msgList1 = violations1.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
-
-		Set<ConstraintViolation<CheckDuplicateEmailRequest>> violations2 = validator.validate(
-			checkDuplicateEmailRequest2);
-		Set<String> msgList2 = violations2.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
-
-		//then
-		assertThat(msgList1).isEqualTo(Set.of("이메일을 입력해 주세요.", "이메일 길이를 확인해 주세요."));
-		assertThat(msgList2).isEqualTo(Set.of("이메일 형식으로 입력해 주세요."));
+		// then
+		assertThat(violations).hasSize(1);
+		assertThat(violations).extracting("message").contains(AuthValidationConstants.EMAIL_NOT_BLANK);
 	}
 
 	@Test
-	@DisplayName("닉네임 중복 체크 검증 테스트")
-	void validateCheckDuplicateNicknameRequest() {
-		CheckDuplicateNicknameRequest checkDuplicateNicknameRequest = CheckDuplicateNicknameRequest.builder()
-			.nickname("")
+	@DisplayName("이메일 주소가 유효하지 않은 경우의 테스트")
+	void invalidEmail() {
+		// given
+		CheckDuplicateEmailRequest request = CheckDuplicateEmailRequest.builder()
+			.email("invalidEmail")
 			.build();
 
-		Set<ConstraintViolation<CheckDuplicateNicknameRequest>> violations = validator.validate(
-			checkDuplicateNicknameRequest);
-		Set<String> msgList = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
+		// when
+		Set<ConstraintViolation<CheckDuplicateEmailRequest>> violations = validator.validate(request,
+			ValidationSequence.class);
 
-		//then
-		assertThat(msgList).isEqualTo(Set.of("닉네임을 입력해 주세요.", "닉네임 길이를 확인해 주세요."));
+		// then
+		assertThat(violations).hasSize(1);
+		assertThat(violations).extracting("message").contains(AuthValidationConstants.EMAIL);
 	}
 
 	@Test
-	@DisplayName("로그인 요청 검증 테스트")
-	void validateLoginRequest() {
-		LoginRequest loginRequest1 = LoginRequest.builder()
-			.email("")
-			.password("")
+	@DisplayName("유효한 닉네임에 대한 테스트")
+	void validNickname() {
+		// given
+		CheckDuplicateNicknameRequest request = CheckDuplicateNicknameRequest.builder()
+			.nickname("validNic")
 			.build();
 
-		LoginRequest loginRequest2 = LoginRequest.builder()
-			.email("asdasdas")
-			.password("asdassdd")
-			.build();
+		// when
+		Set<ConstraintViolation<CheckDuplicateNicknameRequest>> violations = validator.validate(request,
+			ValidationSequence.class);
 
-		Set<ConstraintViolation<LoginRequest>> violations1 = validator.validate(loginRequest1);
-		Set<String> msgList1 = violations1.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
-
-		Set<ConstraintViolation<LoginRequest>> violations2 = validator.validate(loginRequest2);
-		Set<String> msgList2 = violations2.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
-
-		//then
-		assertThat(msgList1).isEqualTo(Set.of("이메일을 입력해 주세요.", "이메일 길이를 확인해 주세요.",
-			"비밀번호를 입력해 주세요.", "비밀번호 길이를 확인해 주세요."));
-
-		assertThat(msgList2).isEqualTo(Set.of("이메일 형식으로 입력해 주세요."));
+		// then
+		assertThat(violations).isEmpty();
 	}
 
 	@Test
-	@DisplayName("회원가입 요청 검증 테스트")
-	void validateSignUpRequest() {
-		SignUpRequest signUpRequest1 = SignUpRequest.builder()
-			.email("")
-			.nickname("")
-			.password("")
+	@DisplayName("유효한 로그인 요청에 대한 테스트")
+	void validLoginRequest() {
+		// given
+		LoginRequest loginRequest = LoginRequest.builder()
+			.email("valid@example.com")
+			.password("ValidPassword123")
 			.build();
 
-		SignUpRequest signUpRequest2 = SignUpRequest.builder()
-			.email("asdasdas")
-			.nickname("홍박사")
-			.password("asdasdas")
-			.build();
+		// when
+		Set<ConstraintViolation<LoginRequest>> violations = validator.validate(loginRequest, ValidationSequence.class);
 
-		Set<ConstraintViolation<SignUpRequest>> violations1 = validator.validate(signUpRequest1);
-		Set<String> msgList1 = violations1.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
-
-		Set<ConstraintViolation<SignUpRequest>> violations2 = validator.validate(signUpRequest2);
-		Set<String> msgList2 = violations2.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
-
-		//then
-		assertThat(msgList1).isEqualTo(Set.of("이메일을 입력해 주세요.", "이메일 길이를 확인해 주세요.",
-			"닉네임을 입력해 주세요.", "닉네임 길이를 확인해 주세요.",
-			"비밀번호를 입력해 주세요.", "비밀번호 길이를 확인해 주세요."));
-
-		assertThat(msgList2).isEqualTo(Set.of("이메일 형식으로 입력해 주세요."));
+		// then
+		assertThat(violations).isEmpty();
 	}
-
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,6 +18,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     compileOnly 'org.projectlombok:lombok'

--- a/core/src/main/java/com/kernelsquare/core/validation/ValidationGroups.java
+++ b/core/src/main/java/com/kernelsquare/core/validation/ValidationGroups.java
@@ -1,0 +1,28 @@
+package com.kernelsquare.core.validation;
+
+public class ValidationGroups {
+	public interface NotBlankGroup {
+	}
+
+	;
+
+	public interface NotNullGroup {
+	}
+
+	;
+
+	public interface PatternGroup {
+	}
+
+	;
+
+	public interface SizeGroup {
+	}
+
+	;
+
+	public interface EmailGroup {
+	}
+
+	;
+}

--- a/core/src/main/java/com/kernelsquare/core/validation/ValidationSequence.java
+++ b/core/src/main/java/com/kernelsquare/core/validation/ValidationSequence.java
@@ -1,0 +1,8 @@
+package com.kernelsquare.core.validation;
+
+import jakarta.validation.GroupSequence;
+
+@GroupSequence({ValidationGroups.NotBlankGroup.class, ValidationGroups.NotNullGroup.class,
+	ValidationGroups.SizeGroup.class, ValidationGroups.PatternGroup.class, ValidationGroups.EmailGroup.class})
+public interface ValidationSequence {
+}

--- a/core/src/main/java/com/kernelsquare/core/validation/constants/AuthValidationConstants.java
+++ b/core/src/main/java/com/kernelsquare/core/validation/constants/AuthValidationConstants.java
@@ -1,0 +1,21 @@
+package com.kernelsquare.core.validation.constants;
+
+public class AuthValidationConstants {
+	// Not Blank
+	public static final String EMAIL_NOT_BLANK = "이메일을 입력해 주세요.";
+	public static final String NICKNAME_NOT_BLANK = "닉네임을 입력해 주세요.";
+	public static final String PASSWORD_NOT_BLANK = "비밀번호를 입력해 주세요.";
+
+	// Size
+	public static final String EMAIL_SIZE = "이메일 길이를 확인해 주세요.";
+	public static final String NICKNAME_SIZE = "닉네임 길이를 확인해 주세요.";
+	public static final String PASSWORD_SIZE = "비밀번호 길이를 확인해 주세요.";
+
+	// Pattern
+	public static final String EMAIL_PATTERN = "이메일에 한글은 허용되지 않습니다.";
+	public static final String NICKNAME_PATTERN = "완전한 한글 조합 또는 영문 대소문자만 입력하세요.";
+	public static final String PASSWORD_PATTERN = "영문 대소문자, 특수문자, 숫자를 각각 1자 이상 포함하세요.";
+
+	// Email
+	public static final String EMAIL = "올바른 이메일을 입력해 주세요";
+}

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/controller/AuthController.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/controller/AuthController.java
@@ -3,11 +3,16 @@ package com.kernelsquare.memberapi.domain.auth.controller;
 import static com.kernelsquare.core.common_response.response.code.AuthResponseCode.*;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kernelsquare.core.common_response.ApiResponse;
+import com.kernelsquare.core.common_response.ResponseEntityFactory;
+import com.kernelsquare.core.validation.ValidationSequence;
+import com.kernelsquare.domainmysql.domain.member.entity.Member;
 import com.kernelsquare.memberapi.domain.auth.dto.CheckDuplicateEmailRequest;
 import com.kernelsquare.memberapi.domain.auth.dto.CheckDuplicateNicknameRequest;
 import com.kernelsquare.memberapi.domain.auth.dto.LoginRequest;
@@ -18,11 +23,7 @@ import com.kernelsquare.memberapi.domain.auth.dto.TokenRequest;
 import com.kernelsquare.memberapi.domain.auth.dto.TokenResponse;
 import com.kernelsquare.memberapi.domain.auth.service.AuthService;
 import com.kernelsquare.memberapi.domain.auth.service.TokenProvider;
-import com.kernelsquare.core.common_response.ApiResponse;
-import com.kernelsquare.core.common_response.ResponseEntityFactory;
-import com.kernelsquare.domainmysql.domain.member.entity.Member;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -33,7 +34,8 @@ public class AuthController {
 	private final TokenProvider tokenProvider;
 
 	@PostMapping("/auth/login")
-	public ResponseEntity<ApiResponse<LoginResponse>> login(final @RequestBody @Valid LoginRequest loginRequest) {
+	public ResponseEntity<ApiResponse<LoginResponse>> login(
+		final @RequestBody @Validated(ValidationSequence.class) LoginRequest loginRequest) {
 		Member member = authService.login(loginRequest);
 		TokenResponse tokenResponse = tokenProvider.createToken(member, loginRequest);
 		LoginResponse loginResponse = LoginResponse.of(member, tokenResponse);
@@ -41,7 +43,8 @@ public class AuthController {
 	}
 
 	@PostMapping("/auth/signup")
-	public ResponseEntity<ApiResponse<SignUpResponse>> signUp(final @RequestBody @Valid SignUpRequest signUpRequest) {
+	public ResponseEntity<ApiResponse<SignUpResponse>> signUp(
+		final @RequestBody @Validated(ValidationSequence.class) SignUpRequest signUpRequest) {
 		SignUpResponse signUpResponse = authService.signUp(signUpRequest);
 		return ResponseEntityFactory.toResponseEntity(SIGN_UP_SUCCESS, signUpResponse);
 	}
@@ -55,14 +58,14 @@ public class AuthController {
 
 	@PostMapping("/auth/check/email")
 	public ResponseEntity<ApiResponse> isEmailUnique(
-		final @Valid @RequestBody CheckDuplicateEmailRequest emailRequest) {
+		final @RequestBody @Validated(ValidationSequence.class) CheckDuplicateEmailRequest emailRequest) {
 		authService.isEmailUnique(emailRequest.email());
 		return ResponseEntityFactory.toResponseEntity(EMAIL_UNIQUE_VALIDATED);
 	}
 
 	@PostMapping("/auth/check/nickname")
 	public ResponseEntity<ApiResponse> isNicknameUnique(
-		final @Valid @RequestBody CheckDuplicateNicknameRequest nicknameRequest) {
+		final @RequestBody @Validated(ValidationSequence.class) CheckDuplicateNicknameRequest nicknameRequest) {
 		authService.isNicknameUnique(nicknameRequest.nickname());
 		return ResponseEntityFactory.toResponseEntity(NICKNAME_UNIQUE_VALIDATED);
 	}

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/CheckDuplicateEmailRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/CheckDuplicateEmailRequest.java
@@ -1,16 +1,20 @@
 package com.kernelsquare.memberapi.domain.auth.dto;
 
+import com.kernelsquare.core.validation.ValidationGroups;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record CheckDuplicateEmailRequest(
 
-	@NotBlank(message = "이메일을 입력해 주세요.")
-	@Email(message = "이메일 형식으로 입력해 주세요.")
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.")
+	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
+	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
 	String email
 ) {
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/CheckDuplicateEmailRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/CheckDuplicateEmailRequest.java
@@ -1,6 +1,7 @@
 package com.kernelsquare.memberapi.domain.auth.dto;
 
 import com.kernelsquare.core.validation.ValidationGroups;
+import com.kernelsquare.core.validation.constants.AuthValidationConstants;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -11,10 +12,10 @@ import lombok.Builder;
 @Builder
 public record CheckDuplicateEmailRequest(
 
-	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
-	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
+	@NotBlank(message = AuthValidationConstants.EMAIL_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = AuthValidationConstants.EMAIL_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = AuthValidationConstants.EMAIL_PATTERN, groups = ValidationGroups.PatternGroup.class)
+	@Email(message = AuthValidationConstants.EMAIL, groups = ValidationGroups.EmailGroup.class)
 	String email
 ) {
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/CheckDuplicateNicknameRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/CheckDuplicateNicknameRequest.java
@@ -1,6 +1,7 @@
 package com.kernelsquare.memberapi.domain.auth.dto;
 
 import com.kernelsquare.core.validation.ValidationGroups;
+import com.kernelsquare.core.validation.constants.AuthValidationConstants;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -9,9 +10,9 @@ import lombok.Builder;
 
 @Builder
 public record CheckDuplicateNicknameRequest(
-	@NotBlank(message = "닉네임을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "완전한 한글 조합 또는 영문 대소문자만 입력하세요.", groups = ValidationGroups.PatternGroup.class)
+	@NotBlank(message = AuthValidationConstants.NICKNAME_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 2, max = 8, message = AuthValidationConstants.NICKNAME_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = AuthValidationConstants.NICKNAME_PATTERN, groups = ValidationGroups.PatternGroup.class)
 	String nickname
 ) {
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/CheckDuplicateNicknameRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/CheckDuplicateNicknameRequest.java
@@ -1,13 +1,17 @@
 package com.kernelsquare.memberapi.domain.auth.dto;
 
+import com.kernelsquare.core.validation.ValidationGroups;
+
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record CheckDuplicateNicknameRequest(
-	@NotBlank(message = "닉네임을 입력해 주세요.")
-	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.")
+	@NotBlank(message = "닉네임을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "완전한 한글 조합 또는 영문 대소문자만 입력하세요.", groups = ValidationGroups.PatternGroup.class)
 	String nickname
 ) {
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/LoginRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/LoginRequest.java
@@ -1,6 +1,7 @@
 package com.kernelsquare.memberapi.domain.auth.dto;
 
 import com.kernelsquare.core.validation.ValidationGroups;
+import com.kernelsquare.core.validation.constants.AuthValidationConstants;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -10,16 +11,13 @@ import lombok.Builder;
 
 @Builder
 public record LoginRequest(
-	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
-	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
+	@NotBlank(message = AuthValidationConstants.EMAIL_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = AuthValidationConstants.EMAIL_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = AuthValidationConstants.EMAIL_PATTERN, groups = ValidationGroups.PatternGroup.class)
+	@Email(message = AuthValidationConstants.EMAIL, groups = ValidationGroups.EmailGroup.class)
 	String email,
 
-	@NotBlank(message = "비밀번호를 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
-		message = "영문 대소문자, 특수문자, 숫자를 각각 1자 이상 포함하세요.", groups = ValidationGroups.PatternGroup.class)
+	@NotBlank(message = AuthValidationConstants.PASSWORD_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
 	String password
 ) {
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/LoginRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/LoginRequest.java
@@ -1,19 +1,25 @@
 package com.kernelsquare.memberapi.domain.auth.dto;
 
+import com.kernelsquare.core.validation.ValidationGroups;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record LoginRequest(
-	@NotBlank(message = "이메일을 입력해 주세요.")
-	@Email(message = "이메일 형식으로 입력해 주세요.")
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.")
+	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
+	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
 	String email,
 
-	@NotBlank(message = "비밀번호를 입력해 주세요.")
-	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.")
+	@NotBlank(message = "비밀번호를 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+		message = "영문 대소문자, 특수문자, 숫자를 각각 1자 이상 포함하세요.", groups = ValidationGroups.PatternGroup.class)
 	String password
 ) {
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/SignUpRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/SignUpRequest.java
@@ -1,6 +1,7 @@
 package com.kernelsquare.memberapi.domain.auth.dto;
 
 import com.kernelsquare.core.validation.ValidationGroups;
+import com.kernelsquare.core.validation.constants.AuthValidationConstants;
 import com.kernelsquare.domainmysql.domain.level.entity.Level;
 import com.kernelsquare.domainmysql.domain.member.entity.Member;
 
@@ -12,21 +13,21 @@ import lombok.Builder;
 
 @Builder
 public record SignUpRequest(
-	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
-	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
+	@NotBlank(message = AuthValidationConstants.EMAIL_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = AuthValidationConstants.EMAIL_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = AuthValidationConstants.EMAIL_PATTERN, groups = ValidationGroups.PatternGroup.class)
+	@Email(message = AuthValidationConstants.EMAIL, groups = ValidationGroups.EmailGroup.class)
 	String email,
 
-	@NotBlank(message = "닉네임을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "완전한 한글 조합 또는 영문 대소문자만 입력하세요.", groups = ValidationGroups.PatternGroup.class)
+	@NotBlank(message = AuthValidationConstants.NICKNAME_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 2, max = 8, message = AuthValidationConstants.NICKNAME_SIZE, groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = AuthValidationConstants.NICKNAME_PATTERN, groups = ValidationGroups.PatternGroup.class)
 	String nickname,
 
-	@NotBlank(message = "비밀번호를 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
-	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@NotBlank(message = AuthValidationConstants.PASSWORD_NOT_BLANK, groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 8, max = 16, message = AuthValidationConstants.PASSWORD_SIZE, groups = ValidationGroups.SizeGroup.class)
 	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
-		message = "영문 대소문자, 특수문자, 숫자를 각각 1자 이상 포함하세요.", groups = ValidationGroups.PatternGroup.class)
+		message = AuthValidationConstants.PASSWORD_PATTERN, groups = ValidationGroups.PatternGroup.class)
 	String password
 ) {
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/SignUpRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/auth/dto/SignUpRequest.java
@@ -1,26 +1,32 @@
 package com.kernelsquare.memberapi.domain.auth.dto;
 
+import com.kernelsquare.core.validation.ValidationGroups;
 import com.kernelsquare.domainmysql.domain.level.entity.Level;
 import com.kernelsquare.domainmysql.domain.member.entity.Member;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record SignUpRequest(
-	@NotBlank(message = "이메일을 입력해 주세요.")
-	@Email(message = "이메일 형식으로 입력해 주세요.")
-	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.")
+	@NotBlank(message = "이메일을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 5, max = 40, message = "이메일 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[^ㄱ-ㅎㅏ-ㅣ가-힣]*$", message = "이메일에 한글은 허용되지 않습니다.", groups = ValidationGroups.PatternGroup.class)
+	@Email(message = "올바른 이메일을 입력해 주세요.", groups = ValidationGroups.EmailGroup.class)
 	String email,
 
-	@NotBlank(message = "닉네임을 입력해 주세요.")
-	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.")
+	@NotBlank(message = "닉네임을 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 2, max = 8, message = "닉네임 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "완전한 한글 조합 또는 영문 대소문자만 입력하세요.", groups = ValidationGroups.PatternGroup.class)
 	String nickname,
 
-	@NotBlank(message = "비밀번호를 입력해 주세요.")
-	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.")
+	@NotBlank(message = "비밀번호를 입력해 주세요.", groups = ValidationGroups.NotBlankGroup.class)
+	@Size(min = 8, max = 16, message = "비밀번호 길이를 확인해 주세요.", groups = ValidationGroups.SizeGroup.class)
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+		message = "영문 대소문자, 특수문자, 숫자를 각각 1자 이상 포함하세요.", groups = ValidationGroups.PatternGroup.class)
 	String password
 ) {
 
@@ -32,7 +38,7 @@ public record SignUpRequest(
 			.password(password)
 			.experience(0L)
 			.imageUrl(null)
-			.introduction(null)
+			.introduction("")
 			.level(level)
 			.build();
 	}

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/dto/UpdateMemberIntroductionRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/dto/UpdateMemberIntroductionRequest.java
@@ -1,11 +1,11 @@
 package com.kernelsquare.memberapi.domain.member.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record UpdateMemberIntroductionRequest(
-	@NotBlank
+	@NotNull(message = "자기 소개글 수정은 null일 수 없습니다.")
 	String introduction
 ) {
 }

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/auth/controller/AuthControllerTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/auth/controller/AuthControllerTest.java
@@ -18,6 +18,11 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kernelsquare.core.type.AuthorityType;
+import com.kernelsquare.domainmysql.domain.authority.entity.Authority;
+import com.kernelsquare.domainmysql.domain.level.entity.Level;
+import com.kernelsquare.domainmysql.domain.member.entity.Member;
+import com.kernelsquare.domainmysql.domain.member_authority.entity.MemberAuthority;
 import com.kernelsquare.memberapi.domain.auth.dto.CheckDuplicateEmailRequest;
 import com.kernelsquare.memberapi.domain.auth.dto.CheckDuplicateNicknameRequest;
 import com.kernelsquare.memberapi.domain.auth.dto.LoginRequest;
@@ -27,11 +32,6 @@ import com.kernelsquare.memberapi.domain.auth.dto.TokenRequest;
 import com.kernelsquare.memberapi.domain.auth.dto.TokenResponse;
 import com.kernelsquare.memberapi.domain.auth.service.AuthService;
 import com.kernelsquare.memberapi.domain.auth.service.TokenProvider;
-import com.kernelsquare.core.type.AuthorityType;
-import com.kernelsquare.domainmysql.domain.authority.entity.Authority;
-import com.kernelsquare.domainmysql.domain.level.entity.Level;
-import com.kernelsquare.domainmysql.domain.member.entity.Member;
-import com.kernelsquare.domainmysql.domain.member_authority.entity.MemberAuthority;
 
 @DisplayName("인증 컨트롤러 테스트")
 @WebMvcTest(AuthController.class)
@@ -132,7 +132,7 @@ public class AuthControllerTest {
 			.builder()
 			.nickname("woww")
 			.email("jugwang@naver.com")
-			.password("hashedPassword")
+			.password("hashedPassw@1d")
 			.build();
 
 		Member member = Member
@@ -140,7 +140,7 @@ public class AuthControllerTest {
 			.id(1L)
 			.nickname("woww")
 			.email("jugwang@naver.com")
-			.password("hashedPassword")
+			.password("hashedPassw@1")
 			.experience(10000L)
 			.introduction("hi, i'm hongjugwang.")
 			.imageUrl("s3:qwe12fasdawczx")


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close #223 

## 개요
> 변경 사항에 대해 간단하게 작성해주세요. 무엇을 왜 수정했는지 설명해주세요.
백엔드 서버에서 AuthController에서 필요한 유효성 검증 추가

## 상세 내용
- 회원가입, 로그인, 이메일 중복, 닉네임 중복 검사 시 한글에 대한 유효성 검증을 추가
- 각 항목에 대해 유효성 검증 순서 추가

