### PR TITLE
[bugfix] 채팅방 비활성화 스케줄링 동작하게끔 SchedulingConfig 추가

### DIFF
--- a/member-api/src/main/java/com/kernelsquare/memberapi/common/config/SchedulingConfig.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.kernelsquare.memberapi.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #225 

## 개요
> 채팅방이 만료되면 비활성화 시키는 스케줄링을 정상적으로 동작시키기 위함

## 상세 내용
- @EnableScheduling가 달린 SchedulingConfig 추가
