### PR TITLE
[bugfix] 멘토링 날짜를 신청하기 누른 날짜로 부터 일주일 뒤부터 가능하게끔 수정

### DIFF
--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/controller/ReservationController.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/controller/ReservationController.java
@@ -17,7 +17,7 @@ import com.kernelsquare.core.common_response.ResponseEntityFactory;
 import com.kernelsquare.memberapi.domain.auth.dto.MemberPrincipal;
 import com.kernelsquare.memberapi.domain.reservation.dto.AddReservationMemberResponse;
 import com.kernelsquare.memberapi.domain.reservation.dto.FindAllReservationResponse;
-import com.kernelsquare.memberapi.domain.reservation.service.AddReservationMemberRequest;
+import com.kernelsquare.memberapi.domain.reservation.dto.AddReservationMemberRequest;
 import com.kernelsquare.memberapi.domain.reservation.service.ReservationService;
 
 import lombok.RequiredArgsConstructor;

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/dto/AddReservationMemberRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/dto/AddReservationMemberRequest.java
@@ -1,4 +1,4 @@
-package com.kernelsquare.memberapi.domain.reservation.service;
+package com.kernelsquare.memberapi.domain.reservation.dto;
 
 import java.time.LocalDateTime;
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/service/ReservationService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/service/ReservationService.java
@@ -3,6 +3,7 @@ package com.kernelsquare.memberapi.domain.reservation.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.kernelsquare.memberapi.domain.reservation.dto.AddReservationMemberRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
@@ -107,7 +107,7 @@ public class ReservationArticleService {
 		}
 
 		// 예약 생성 기한 체크 로직 (7일 이후, 한달 이전)
-		if (!startTime.toLocalDate().isAfter(currentDate.plusDays(7)) && currentDate.isBefore(
+		if (!startTime.toLocalDate().isAfter(currentDate.plusDays(6)) && currentDate.isBefore(
 			currentDate.plusMonths(1))) {
 			throw new BusinessException(ReservationArticleErrorCode.RESERVATION_PERIOD_LIMIT);
 		}

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation/controller/ReservationControllerTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation/controller/ReservationControllerTest.java
@@ -36,7 +36,7 @@ import com.kernelsquare.memberapi.domain.auth.dto.MemberPrincipal;
 import com.kernelsquare.memberapi.domain.reservation.dto.AddReservationMemberResponse;
 import com.kernelsquare.memberapi.domain.reservation.dto.FindAllReservationResponse;
 import com.kernelsquare.memberapi.domain.reservation.dto.FindReservationResponse;
-import com.kernelsquare.memberapi.domain.reservation.service.AddReservationMemberRequest;
+import com.kernelsquare.memberapi.domain.reservation.dto.AddReservationMemberRequest;
 import com.kernelsquare.memberapi.domain.reservation.service.ReservationService;
 
 @DisplayName("예약 컨트롤러 테스트")

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation/service/ReservationServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation/service/ReservationServiceTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.kernelsquare.memberapi.domain.reservation.dto.AddReservationMemberRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #227 

## 개요
> 멘토링 가능 날짜 중 첫날에 예약이 안되는 버그를 해결하기 위함

## 상세 내용
- ReservationArticleService의 !startTime.toLocalDate().isAfter(currentDate.plusDays(7))에서 !startTime.toLocalDate().isAfter(currentDate.plusDays(6))로 수정
- 추가적으로 AddReservationMemberRequest 위치를 service에서 dto로 이동
