### PR TITLE
[bugfix] 예약창 생성 시 예약 일시 체크 로직을 LocalDateTime으로 수정

### DIFF
--- a/domain-mysql/src/test/java/com/kernelsquare/domainmysql/domain/reservation/repository/ReservationRepositoryTest.java
+++ b/domain-mysql/src/test/java/com/kernelsquare/domainmysql/domain/reservation/repository/ReservationRepositoryTest.java
@@ -59,7 +59,7 @@ class ReservationRepositoryTest {
     }
 
     @Test
-    @DisplayName("회원 아이디와 진행 중인 예약이 현재 시간 이후에 종료되는지 여부 조회")
+    @DisplayName("예약창이 이미 존재하는지 조회 (현재 시점에서 뒤에 남아있는 예약 존재 여부 확인)")
     void testExistsByMemberIdAndFinishedIsFalseAndEndTimeAfter() {
         //given
         reservationRepository.save(testReservation);

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
@@ -74,7 +74,7 @@ public class ReservationArticleService {
 			hashtagRepository.save(hashTag);
 		}
 
-		LocalDateTime currentDateTime = LocalDateTime.now().toLocalDate();
+		LocalDateTime currentDateTime = LocalDateTime.now();
 		LocalDateTime startTime = LocalDateTime.MAX;
 		LocalDateTime endTime = LocalDateTime.MIN;
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
@@ -75,7 +75,7 @@ public class ReservationArticleService {
 		}
 
 		//todo : 클라이언트와 서버 시간이 다름 (영국 시간대) 어떻게
-		LocalDate currentDate = LocalDateTime.now().toLocalDate();
+		LocalDateTime currentDateTime = LocalDateTime.now();
 		LocalDateTime startTime = LocalDateTime.MAX;
 		LocalDateTime endTime = LocalDateTime.MIN;
 
@@ -109,8 +109,8 @@ public class ReservationArticleService {
 		}
 
 		// 예약 생성 기한 체크 로직 (7일 이후, 한달 이전)
-		if (!(startTime.toLocalDate().isAfter(currentDate.plusDays(6)) && startTime.toLocalDate().isBefore(
-			currentDate.plusMonths(1)))) {
+		if (!(startTime.isAfter(currentDateTime.plusDays(6)) && startTime.isBefore(
+				currentDateTime.plusMonths(1)))) {
 			throw new BusinessException(ReservationArticleErrorCode.RESERVATION_PERIOD_LIMIT);
 		}
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
@@ -74,7 +74,7 @@ public class ReservationArticleService {
 			hashtagRepository.save(hashTag);
 		}
 
-		LocalDate currentDate = LocalDateTime.now().toLocalDate();
+		LocalDate currentDateTime = LocalDateTime.now().toLocalDate();
 		LocalDateTime startTime = LocalDateTime.MAX;
 		LocalDateTime endTime = LocalDateTime.MIN;
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
@@ -74,7 +74,7 @@ public class ReservationArticleService {
 			hashtagRepository.save(hashTag);
 		}
 
-		LocalDate currentDateTime = LocalDateTime.now().toLocalDate();
+		LocalDateTime currentDateTime = LocalDateTime.now().toLocalDate();
 		LocalDateTime startTime = LocalDateTime.MAX;
 		LocalDateTime endTime = LocalDateTime.MIN;
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
@@ -91,6 +91,10 @@ public class ReservationArticleService {
 				startTime = dateTime;
 			}
 
+			if (endTime.isBefore(dateTime.plusMinutes(30))) {
+				endTime = dateTime.plusMinutes(30);
+			}
+
 			// Reservation 생성 및 설정
 			Reservation reservation = Reservation.builder()
 				.startTime(dateTime)
@@ -103,8 +107,8 @@ public class ReservationArticleService {
 		}
 
 		// 3일 기간 체크
-		Long checkDurationDay = ChronoUnit.DAYS.between(startTime.toLocalDate(), endTime.toLocalDate());
-		if (checkDurationDay > 3) {
+		Long checkDurationDay = ChronoUnit.SECONDS.between(startTime, endTime);
+		if (checkDurationDay > 3 * 24 * 60 * 60) {
 			throw new BusinessException(ReservationArticleErrorCode.RESERVATION_TIME_LIMIT);
 		}
 

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
@@ -177,7 +177,7 @@ class ReservationArticleServiceTest {
 
 		// Verify
 		verify(memberRepository, times(1)).findById(anyLong());
-		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
+		verify(reservationRepository, times(1)).existsByMemberIdAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
 		verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
 	}
 
@@ -208,7 +208,7 @@ class ReservationArticleServiceTest {
 						List.of(LocalDateTime.now().plusDays(40L), LocalDateTime.now().plusDays(41L)));
 
 		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
-		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class))).willReturn(
+		given(reservationRepository.existsByMemberIdAndEndTimeAfter(anyLong(), any(LocalDateTime.class))).willReturn(
 				false
 		);
 		given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
@@ -224,7 +224,7 @@ class ReservationArticleServiceTest {
 
 		// Verify
 		verify(memberRepository, times(1)).findById(anyLong());
-		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
+		verify(reservationRepository, times(1)).existsByMemberIdAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
 		verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
 	}
 
@@ -255,7 +255,7 @@ class ReservationArticleServiceTest {
 						List.of(LocalDateTime.now().plusDays(7L), LocalDateTime.now().plusDays(11L).plusMinutes(30L)));
 
 		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
-		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class))).willReturn(
+		given(reservationRepository.existsByMemberIdAndEndTimeAfter(anyLong(), any(LocalDateTime.class))).willReturn(
 				false
 		);
 		given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
@@ -271,7 +271,7 @@ class ReservationArticleServiceTest {
 
 		// Verify
 		verify(memberRepository, times(1)).findById(anyLong());
-		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
+		verify(reservationRepository, times(1)).existsByMemberIdAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
 		verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
 	}
 

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
@@ -162,7 +162,7 @@ class ReservationArticleServiceTest {
 				List.of(LocalDateTime.now().plusDays(7), LocalDateTime.now().plusDays(8)));
 
 		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
-		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class))).willReturn(
+		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class))).willReturn(
 				false
 		);
 		given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
@@ -177,7 +177,7 @@ class ReservationArticleServiceTest {
 
 		// Verify
 		verify(memberRepository, times(1)).findById(anyLong());
-		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class));
+		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
 		verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
 	}
 
@@ -208,7 +208,7 @@ class ReservationArticleServiceTest {
 						List.of(LocalDateTime.now().plusDays(40L), LocalDateTime.now().plusDays(41L)));
 
 		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
-		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class))).willReturn(
+		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class))).willReturn(
 				false
 		);
 		given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
@@ -224,7 +224,7 @@ class ReservationArticleServiceTest {
 
 		// Verify
 		verify(memberRepository, times(1)).findById(anyLong());
-		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class));
+		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
 		verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
 	}
 
@@ -255,7 +255,7 @@ class ReservationArticleServiceTest {
 						List.of(LocalDateTime.now().plusDays(7L), LocalDateTime.now().plusDays(11L).plusMinutes(30L)));
 
 		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
-		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class))).willReturn(
+		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class))).willReturn(
 				false
 		);
 		given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
@@ -271,7 +271,7 @@ class ReservationArticleServiceTest {
 
 		// Verify
 		verify(memberRepository, times(1)).findById(anyLong());
-		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class));
+		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
 		verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
 	}
 

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
@@ -8,6 +8,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.kernelsquare.core.common_response.error.code.ReservationArticleErrorCode;
+import com.kernelsquare.core.common_response.error.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,6 +94,13 @@ class ReservationArticleServiceTest {
 			.build();
 	}
 
+	private Reservation createTestReservationStartTime(ChatRoom chatRoom, LocalDateTime startTime) {
+		return Reservation.builder()
+				.chatRoom(chatRoom)
+				.startTime(startTime)
+				.build();
+	}
+
 	private Member createTestMember() {
 		return Member.builder()
 			.id(1L)
@@ -167,8 +176,59 @@ class ReservationArticleServiceTest {
 		assertThat(createReservationArticleResponse.reservationArticleId()).isEqualTo(reservationArticle.getId());
 
 		// Verify
+		verify(memberRepository, times(1)).findById(anyLong());
+		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class));
 		verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
 	}
+
+	@Test
+	@DisplayName("예약게시글 생성 가능 일시(LocalDateTime) 초과시 에러 메시지")
+	void testCreateReservationArticleExceedDateTime() {
+		// Given
+		member = createTestMember();
+		authority = createTestAuthority();
+		memberRole = createTestRole(member, authority);
+
+		List<MemberAuthority> memberAuthorityList = List.of(memberRole);
+
+		member.initAuthorities(memberAuthorityList);
+
+		ReservationArticle reservationArticle = createTestReservationArticle(1L);
+
+		LocalDateTime localDateTime = LocalDateTime.now().plusDays(8L);
+
+		reservationArticle.addStartTime(localDateTime);
+
+		Hashtag hashtag = createTestHashtag();
+
+		CreateReservationArticleRequest createReservationArticleRequest =
+				new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(),
+						reservationArticle.getContent(),
+						List.of(hashtag.getContent()),
+						List.of(LocalDateTime.now().plusDays(40L), LocalDateTime.now().plusDays(41L)));
+
+		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
+		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class))).willReturn(
+				false
+		);
+		given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
+
+		// When
+
+		// Then
+		assertThatThrownBy(() ->
+				reservationArticleService.createReservationArticle(createReservationArticleRequest))
+				.isExactlyInstanceOf(BusinessException.class)
+				.extracting("errorCode")
+				.isEqualTo(ReservationArticleErrorCode.RESERVATION_PERIOD_LIMIT);
+
+		// Verify
+		verify(memberRepository, times(1)).findById(anyLong());
+		verify(reservationRepository, times(1)).existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class));
+		verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
+	}
+
+
 
 	@Test
 	@DisplayName("모든 예약창 조회 테스트")

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
@@ -159,7 +159,7 @@ class ReservationArticleServiceTest {
 			new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(),
 				reservationArticle.getContent(),
 				List.of(hashtag.getContent()),
-				List.of(LocalDateTime.now().plusDays(8), LocalDateTime.now().plusDays(9)));
+				List.of(LocalDateTime.now().plusDays(7), LocalDateTime.now().plusDays(8)));
 
 		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
 		given(reservationRepository.existsByMemberIdAndFinishedIsFalseAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class))).willReturn(


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #239 

## 개요
> 예약 생성 기한 체크 로직 (7일 이후, 한달 이전)이 돌아갈 때 LocalDateTime 변환
> 예약 생성 시간 3일 제한 로직 LocalDateTime 변환 및 로직 디버깅
> 관련하여 테스트코드 작성

## 상세 내용
- 개요를 확인할 것
