### PR TITLE
[refactor] enum type에 대한 유효성 검증 커스텀 어노테이션 수정

### DIFF
--- a/admin-api/src/main/java/com/kernelsquare/adminapi/domain/notice/dto/NoticeDto.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/domain/notice/dto/NoticeDto.java
@@ -3,6 +3,7 @@ package com.kernelsquare.adminapi.domain.notice.dto;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.kernelsquare.core.validation.validator.EnumValue;
 import com.kernelsquare.domainmysql.domain.notice.entity.Notice;
 
 import jakarta.validation.constraints.NotBlank;
@@ -20,8 +21,8 @@ public class NoticeDto {
 		@Size(min = 10, max = 10000, message = "공지 내용은 10자 이상 1000자 이하로 작성해 주세요")
 		String noticeContent,
 
-		// @EnumValue(enumClass = Notice.NoticeCategory.class, message = "유효한 카테고리를 선택해주세요")
-		Notice.NoticeCategory noticeCategory
+		@EnumValue(enumClass = Notice.NoticeCategory.class, message = "유효한 카테고리를 선택해주세요")
+		String noticeCategory
 	) {
 	}
 

--- a/admin-api/src/test/java/com/kernelsquare/adminapi/domain/notice/controller/NoticeControllerTest.java
+++ b/admin-api/src/test/java/com/kernelsquare/adminapi/domain/notice/controller/NoticeControllerTest.java
@@ -54,7 +54,7 @@ public class NoticeControllerTest {
 	void testCreateNotice() throws Exception {
 		//given
 		NoticeDto.CreateRequest request = NoticeDto.CreateRequest.builder()
-			.noticeCategory(Notice.NoticeCategory.GENERAL)
+			.noticeCategory("일반 공지")
 			.noticeContent("Lets roll out")
 			.noticeTitle("환불 관련 공지입니다.")
 			.build();
@@ -86,7 +86,7 @@ public class NoticeControllerTest {
 			.andDo(document("notice-created", getDocumentRequest(), getDocumentResponse(),
 				requestFields(fieldWithPath("notice_title").type(JsonFieldType.STRING).description("공지 제목"),
 					fieldWithPath("notice_content").type(JsonFieldType.STRING).description("공지 내용"),
-					fieldWithPath("notice_category").type(JsonFieldType.STRING).description("일반 공지")),
+					fieldWithPath("notice_category").type(JsonFieldType.STRING).description("공지 카테고리")),
 				responseFields(fieldWithPath("msg").type(JsonFieldType.STRING).description("응답 메시지"),
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태 코드"),
 					fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답"),

--- a/core/src/main/java/com/kernelsquare/core/validation/validator/ValueOfEnumValidator.java
+++ b/core/src/main/java/com/kernelsquare/core/validation/validator/ValueOfEnumValidator.java
@@ -1,30 +1,41 @@
 package com.kernelsquare.core.validation.validator;
 
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Stream;
+
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
 public class ValueOfEnumValidator implements ConstraintValidator<EnumValue, String> {
 
-	private EnumValue enumValue;
+	private List<String> acceptedValues;
 
 	@Override
 	public void initialize(EnumValue constraintAnnotation) {
-		this.enumValue = constraintAnnotation;
+		acceptedValues = Stream.of(constraintAnnotation.enumClass().getEnumConstants())
+			.map(this::getDescription)
+			.toList();
+
+		System.out.println(acceptedValues);
 	}
 
 	@Override
 	public boolean isValid(String value, ConstraintValidatorContext context) {
-		boolean result = false;
-		Enum<?>[] enumValues = this.enumValue.enumClass().getEnumConstants();
-		if (enumValues != null) {
-			for (Object enumValue : enumValues) {
-				if (value.equals(enumValue.toString())
-					|| this.enumValue.ignoreCase() && value.equalsIgnoreCase(enumValue.toString())) {
-					result = true;
-					break;
-				}
-			}
+		if (value == null) {
+			return true;
 		}
-		return result;
+
+		return acceptedValues.contains(value.toString());
+	}
+
+	private String getDescription(Enum<?> enumValue) {
+		try {
+			Field descriptionField = enumValue.getClass().getDeclaredField("description");
+			descriptionField.setAccessible(true);
+			return (String)descriptionField.get(enumValue);
+		} catch (NoSuchFieldException | IllegalAccessException e) {
+			return enumValue.name();
+		}
 	}
 }


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close #277

## 개요
> 변경 사항에 대해 간단하게 작성해주세요. 무엇을 왜 수정했는지 설명해주세요.
* NoticeDto에 있던 NoticeCategory에 대한 유효성 검증용 custom annotation 수정
* 이후 다른 enum type도 위 어노테이션을 통해서 검증 가능합니다.

## 상세 내용
- reflection을 이용해서 enum type 내부 description field를 들여다보고 해당 값을 요청을 통해 잘 받아오는지에 대해 검증할 수 있도록 Validator 로직을 수정했습니다.
