### PR TITLE
fix: 비지니스 정책과 채팅방 이름 길이 제한이 안맞는 부분 수정

### DIFF
--- a/domain-mysql/src/main/resources/db/migration/V2.1__alter_table.sql
+++ b/domain-mysql/src/main/resources/db/migration/V2.1__alter_table.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `chat_room`
-    ADD COLUMN `room_name` VARCHAR(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    MODIFY COLUMN `room_name` VARCHAR(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL;

--- a/domain-mysql/src/main/resources/db/migration/V2.1__alter_table.sql
+++ b/domain-mysql/src/main/resources/db/migration/V2.1__alter_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `chat_room`
+    ADD COLUMN `room_name` VARCHAR(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL;


### PR DESCRIPTION
- varchar 20에서 100으로 수정

## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [ ] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #308 

## 개요
> 에러 로그를 보니 커피챗 글 제목이 20자를 넘으면 채팅방 입장이 안되는 현상을 해결하기 위함

## 상세 내용
- 플라이웨이 sql를 이용하여 채팅방 이름 길이 제한 수정(varchar 20 -> 100)
- 버전은 V2.1
