### PR TITLE
[fix] 커피챗 과거 시간은 예약되지 않도록 검증하는 로직 추가

### DIFF
--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/dto/AddReservationMemberRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/dto/AddReservationMemberRequest.java
@@ -13,15 +13,15 @@ public record AddReservationMemberRequest(
 	Long reservationArticleId,
 	Long reservationId,
 	Long memberId,
-	LocalDateTime startTime
+	LocalDateTime reservationStartTime
 ) {
 
 	public static Reservation toEntity(AddReservationMemberRequest addReservationMemberRequest,
 		ReservationArticle reservationArticle,
 		ChatRoom chatRoom) {
 		return Reservation.builder()
-			.startTime(addReservationMemberRequest.startTime())
-			.endTime(addReservationMemberRequest.startTime().plusMinutes(30L))
+			.startTime(addReservationMemberRequest.reservationStartTime())
+			.endTime(addReservationMemberRequest.reservationStartTime().plusMinutes(30L))
 			.reservationArticle(reservationArticle)
 			.chatRoom(chatRoom)
 			.build();

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/service/ReservationService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/service/ReservationService.java
@@ -61,6 +61,11 @@ public class ReservationService {
 			throw new BusinessException(ReservationErrorCode.RESERVATION_AVAILABLE_TIME_PASSED);
 		}
 
+		// 예약하려는 시간이 현재 시간보다 이전인지 체크(이전이면 예외처리)
+		if (addReservationMemberRequest.reservationStartTime().isBefore(LocalDateTime.now())) {
+			throw new BusinessException(ReservationErrorCode.RESERVATION_AVAILABLE_TIME_PASSED);
+		}
+
 		List<Reservation> reservationList = reservationRepository.findAllByMemberId(
 			memberId);
 
@@ -84,7 +89,7 @@ public class ReservationService {
 
 		// 예약 중복 확인 체크하기
 		for (Reservation bookedReservation : reservationList) {
-			if (bookedReservation.getStartTime().equals(addReservationMemberRequest.startTime())) {
+			if (bookedReservation.getStartTime().equals(addReservationMemberRequest.reservationStartTime())) {
 				throw new BusinessException(ReservationErrorCode.DUPLICATE_RESERVATION_TIME);
 			}
 		}

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation/controller/ReservationControllerTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation/controller/ReservationControllerTest.java
@@ -193,7 +193,7 @@ class ReservationControllerTest {
 			.reservationArticleId(1L)
 			.reservationId(1L)
 			.memberId(1L)
-			.startTime(LocalDateTime.now())
+			.reservationStartTime(LocalDateTime.now())
 			.build();
 
 		AddReservationMemberResponse addReservationMemberResponse = AddReservationMemberResponse
@@ -245,7 +245,7 @@ class ReservationControllerTest {
 					fieldWithPath("reservation_id").type(JsonFieldType.NUMBER).description("예약 아이디"),
 					fieldWithPath("member_id").type(JsonFieldType.NUMBER).description("회원 아이디"),
 					//todo : 시작 시간 type 확인 -> ARRAY 맞음?
-					fieldWithPath("start_time").type(JsonFieldType.ARRAY).description("시작 시간")
+					fieldWithPath("reservation_start_time").type(JsonFieldType.ARRAY).description("시작 시간")
 				),
 				responseFields(
 					fieldWithPath("msg").type(JsonFieldType.STRING).description("응답 메시지"),

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation/service/ReservationServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation/service/ReservationServiceTest.java
@@ -120,7 +120,7 @@ class ReservationServiceTest {
 			.builder()
 			.reservationId(1L)
 			.reservationArticleId(3L)
-			.startTime(LocalDateTime.now())
+			.reservationStartTime(LocalDateTime.now().plusSeconds(1L))
 			.build();
 
 		reservationList.add(newReservation);


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #320 

## 개요
> 과거시간은 예약 불가하도록 로직 추가

## 상세 내용
- Requset 변수명 헷갈리지 않게 변경
- 기존에 있던 예약가능한 시간이 아닙니다 에러코드 재활용
- 과거 시간은 예약되지 않게 로직 추가