### PR TITLE
[bugfix] rankAnswer 스케줄러에 봇이 단 답변 제외하게끔 로직 수정

### DIFF
--- a/core/src/main/java/com/kernelsquare/core/constants/SystemConstants.java
+++ b/core/src/main/java/com/kernelsquare/core/constants/SystemConstants.java
@@ -2,4 +2,5 @@ package com.kernelsquare.core.constants;
 
 public class SystemConstants {
     public static final String ALERT_SYSTEM = "scheduler_manager";
+    public static final String ANSWER_BOT = "커널스퀘어 AI 인턴";
 }

--- a/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/answer/repository/AnswerReaderImpl.java
+++ b/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/answer/repository/AnswerReaderImpl.java
@@ -1,5 +1,6 @@
 package com.kernelsquare.domainmysql.domain.answer.repository;
 
+import com.kernelsquare.core.constants.SystemConstants;
 import com.kernelsquare.domainmysql.domain.answer.entity.Answer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,6 @@ public class AnswerReaderImpl implements AnswerReader {
 
     @Override
     public List<Answer> findAnswersTop3(Long questionId) {
-        return answerRepository.findAnswersByQuestionIdSortedByVoteCount(questionId);
+        return answerRepository.findAnswersByQuestionIdSortedByVoteCount(questionId, SystemConstants.ANSWER_BOT);
     }
 }

--- a/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/answer/repository/AnswerRepository.java
+++ b/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/answer/repository/AnswerRepository.java
@@ -21,8 +21,9 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 	@Query("UPDATE Answer a SET a.voteCount = a.voteCount - 1 WHERE a.id = :answerId")
 	void downVoteAnswer(@Param("answerId") Long answerId);
 
-	@Query("SELECT a FROM Answer a WHERE a.question.id = :questionId ORDER BY a.voteCount DESC, a.createdDate ASC LIMIT 3")
-	List<Answer> findAnswersByQuestionIdSortedByVoteCount(@Param("questionId") Long questionId);
+	@Query("SELECT a FROM Answer a WHERE a.question.id = :questionId AND a.member.nickname <> :answerBot " +
+		"ORDER BY a.voteCount DESC, a.createdDate ASC LIMIT 3")
+	List<Answer> findAnswersByQuestionIdSortedByVoteCount(@Param("questionId") Long questionId, @Param("answerBot") String answerBot);
 
 	Boolean existsByMemberNicknameAndQuestionId(String nickname, Long questionId);
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/scheduler/manager/SchedulerManagerImpl.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/scheduler/manager/SchedulerManagerImpl.java
@@ -1,6 +1,5 @@
 package com.kernelsquare.memberapi.domain.scheduler.manager;
 
-import com.kernelsquare.core.constants.SystemConstants;
 import com.kernelsquare.core.type.MessageType;
 import com.kernelsquare.domainmysql.domain.answer.entity.Answer;
 import com.kernelsquare.domainmysql.domain.answer.repository.AnswerReader;

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/scheduler/manager/SchedulerManagerImpl.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/scheduler/manager/SchedulerManagerImpl.java
@@ -69,6 +69,10 @@ public class SchedulerManagerImpl implements ScheculerManager {
                 Long rankName = 1L;
 
                 for (Answer answer : answers) {
+                    if (answer.getMember().getNickname().equals("커널스퀘어 AI 인턴")) {
+                        continue;
+                    }
+
                     Rank rank = rankReader.findRank(rankName);
                     answer.updateRank(rank);
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/scheduler/manager/SchedulerManagerImpl.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/scheduler/manager/SchedulerManagerImpl.java
@@ -70,10 +70,6 @@ public class SchedulerManagerImpl implements ScheculerManager {
                 Long rankName = 1L;
 
                 for (Answer answer : answers) {
-                    if (answer.getMember().getNickname().equals(SystemConstants.ANSWER_BOT)) {
-                        continue;
-                    }
-
                     Rank rank = rankReader.findRank(rankName);
                     answer.updateRank(rank);
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/scheduler/manager/SchedulerManagerImpl.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/scheduler/manager/SchedulerManagerImpl.java
@@ -1,5 +1,6 @@
 package com.kernelsquare.memberapi.domain.scheduler.manager;
 
+import com.kernelsquare.core.constants.SystemConstants;
 import com.kernelsquare.core.type.MessageType;
 import com.kernelsquare.domainmysql.domain.answer.entity.Answer;
 import com.kernelsquare.domainmysql.domain.answer.repository.AnswerReader;
@@ -69,7 +70,7 @@ public class SchedulerManagerImpl implements ScheculerManager {
                 Long rankName = 1L;
 
                 for (Answer answer : answers) {
-                    if (answer.getMember().getNickname().equals("커널스퀘어 AI 인턴")) {
+                    if (answer.getMember().getNickname().equals(SystemConstants.ANSWER_BOT)) {
                         continue;
                     }
 


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #325 

## 개요
> 현재 답변 랭킹 스케줄러에 모든 답변들 중 상위 3개를 가져오는 것이기 때문에 봇이 단 답변도 포함되는 문제를 해결하기 위함

## 상세 내용
- answerRepository의 findAnswersByQuestionIdSortedByVoteCount 메서드에서 상위 3개를 가져올 때, answer의 작성자가 봇이 아닌 경우라는 조건을 추가 
