### PR TITLE
[bugfix] 질문 목록 조회 시 생성 날짜 기준으로 내림차순 정렬을 하도록 변경

### DIFF
--- a/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/question/entity/Question.java
+++ b/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/question/entity/Question.java
@@ -45,7 +45,7 @@ public class Question extends BaseEntity {
 	private List<QuestionTechStack> techStackList;
 
 	@OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE)
-	private List<Answer> asnwerList;
+	private List<Answer> answerList;
 
 	@Builder
 	public Question(Long id, String title, String content, String imageUrl, Long viewCount, Boolean closedStatus,

--- a/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/question/entity/Question.java
+++ b/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/question/entity/Question.java
@@ -2,22 +2,12 @@ package com.kernelsquare.domainmysql.domain.question.entity;
 
 import java.util.List;
 
+import com.kernelsquare.domainmysql.domain.answer.entity.Answer;
 import com.kernelsquare.domainmysql.domain.base.BaseEntity;
 import com.kernelsquare.domainmysql.domain.member.entity.Member;
 import com.kernelsquare.domainmysql.domain.question_tech_stack.entity.QuestionTechStack;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.ConstraintMode;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,6 +43,9 @@ public class Question extends BaseEntity {
 
 	@OneToMany(mappedBy = "question")
 	private List<QuestionTechStack> techStackList;
+
+	@OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE)
+	private List<Answer> asnwerList;
 
 	@Builder
 	public Question(Long id, String title, String content, String imageUrl, Long viewCount, Boolean closedStatus,

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/question/controller/QuestionController.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/question/controller/QuestionController.java
@@ -56,7 +56,7 @@ public class QuestionController {
 
 	@GetMapping("/questions")
 	public ResponseEntity<ApiResponse<PageResponse<FindQuestionResponse>>> findAllQuestions(
-		@PageableDefault(page = 0, size = 5, sort = "id", direction = Sort.Direction.DESC)
+		@PageableDefault(page = 0, size = 5, sort = "createdDate", direction = Sort.Direction.DESC)
 		Pageable pageable
 	) {
 		PageResponse<FindQuestionResponse> pageResponse = questionService.findAllQuestions(pageable);

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/question/controller/QuestionController.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/question/controller/QuestionController.java
@@ -56,7 +56,7 @@ public class QuestionController {
 
 	@GetMapping("/questions")
 	public ResponseEntity<ApiResponse<PageResponse<FindQuestionResponse>>> findAllQuestions(
-		@PageableDefault(page = 0, size = 5, sort = "createdDate", direction = Sort.Direction.DESC)
+		@PageableDefault(page = 0, size = 10, sort = "createdDate", direction = Sort.Direction.DESC)
 		Pageable pageable
 	) {
 		PageResponse<FindQuestionResponse> pageResponse = questionService.findAllQuestions(pageable);


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #326 

## 개요
> 현재 로직 상 질문 조회시 id로 정렬을 하다보니, id 순 질문 목록과 createdDate 순 질문 목록이 다를 수 있음을 인지하였고, 수정하기 위함

## 상세 내용
- QuestionController의 findAllQuestions에서 @PageableDefault의 sort를 id에서 createdDate로 변경
