### PR TITLE
[refactor] 멘토링 UI / UX 개선 및 버그 픽스로 인한 API 수정

### DIFF
--- a/core/src/main/java/com/kernelsquare/core/validation/validator/BadWordValidator.java
+++ b/core/src/main/java/com/kernelsquare/core/validation/validator/BadWordValidator.java
@@ -1,12 +1,14 @@
 package com.kernelsquare.core.validation.validator;
 
+import java.util.List;
+
 import com.kernelsquare.core.validation.annotations.BadWordFilter;
 import com.vane.badwordfiltering.BadWordFiltering;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class BadWordValidator implements ConstraintValidator<BadWordFilter, String> {
+public class BadWordValidator implements ConstraintValidator<BadWordFilter, Object> {
 	private BadWordFiltering badWordFiltering;
 	@Override
 	public void initialize(BadWordFilter constraintAnnotation) {
@@ -14,7 +16,17 @@ public class BadWordValidator implements ConstraintValidator<BadWordFilter, Stri
 	}
 
 	@Override
-	public boolean isValid(String value, ConstraintValidatorContext context) {
-		return !badWordFiltering.check(value);
+	public boolean isValid(Object value, ConstraintValidatorContext context) {
+		return switch (value) {
+			case String str -> !badWordFiltering.check(str);
+			case List<?> list -> handleStringList((List<?>) list);
+			default -> true;
+		};
+	}
+
+	private boolean handleStringList(List<?> list) {
+		return list.stream()
+			.map(String.class::cast)
+			.noneMatch(badWordFiltering::check);
 	}
 }

--- a/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/reservation_article/entity/ReservationArticle.java
+++ b/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/reservation_article/entity/ReservationArticle.java
@@ -3,6 +3,8 @@ package com.kernelsquare.domainmysql.domain.reservation_article.entity;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.hibernate.annotations.DynamicUpdate;
+
 import com.kernelsquare.domainmysql.domain.base.BaseEntity;
 import com.kernelsquare.domainmysql.domain.hashtag.entity.Hashtag;
 import com.kernelsquare.domainmysql.domain.member.entity.Member;
@@ -23,6 +25,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "ReservationArticle")
 @Table(name = "reservation_article")
 @Getter
+@DynamicUpdate
 @NoArgsConstructor
 public class ReservationArticle extends BaseEntity {
 	@Id
@@ -64,9 +67,10 @@ public class ReservationArticle extends BaseEntity {
 		this.endTime = endTime;
 	}
 
-	public void update(String title, String content) {
+	public void update(String title, String content, String introduction) {
 		this.title = title;
 		this.content = content;
+		this.introduction = introduction;
 	}
 
 	public void addStartTime(LocalDateTime startTime) {

--- a/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/reservation_article/entity/ReservationArticle.java
+++ b/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/reservation_article/entity/ReservationArticle.java
@@ -39,21 +39,29 @@ public class ReservationArticle extends BaseEntity {
 	@Column(nullable = false, name = "content", columnDefinition = "text")
 	private String content;
 
+	@Column(nullable = false, name = "introduction", columnDefinition = "varchar(200)")
+	private String introduction;
+
 	@Column(nullable = false, name = "start_time", columnDefinition = "datetime")
 	private LocalDateTime startTime;
+
+	@Column(nullable = false, name = "end_time", columnDefinition = "datetime")
+	private LocalDateTime endTime;
 
 	@OneToMany(mappedBy = "reservationArticle")
 	private List<Hashtag> hashtagList;
 
 	@Builder
-	public ReservationArticle(Long id, Member member, String title, String content,
-		List<Hashtag> hashtagList, LocalDateTime startTime) {
+	public ReservationArticle(Long id, Member member, String title, String content, String introduction,
+		List<Hashtag> hashtagList, LocalDateTime startTime, LocalDateTime endTime) {
 		this.id = id;
 		this.member = member;
 		this.title = title;
 		this.content = content;
+		this.introduction = introduction;
 		this.hashtagList = hashtagList;
 		this.startTime = startTime;
+		this.endTime = endTime;
 	}
 
 	public void update(String title, String content) {
@@ -63,5 +71,9 @@ public class ReservationArticle extends BaseEntity {
 
 	public void addStartTime(LocalDateTime startTime) {
 		this.startTime = startTime;
+	}
+
+	public void addEndTime(LocalDateTime startTime) {
+		this.endTime = endTime;
 	}
 }

--- a/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/reservation_article/repository/ReservationArticleRepository.java
+++ b/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/reservation_article/repository/ReservationArticleRepository.java
@@ -1,9 +1,11 @@
 package com.kernelsquare.domainmysql.domain.reservation_article.repository;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kernelsquare.domainmysql.domain.reservation_article.entity.ReservationArticle;
 
 public interface ReservationArticleRepository extends JpaRepository<ReservationArticle, Long> {
-
+	Long countAllByMemberIdAndEndTimeBefore(Long memberId, LocalDateTime time);
 }

--- a/domain-mysql/src/main/resources/db/migration/V2.4__alter_table.sql
+++ b/domain-mysql/src/main/resources/db/migration/V2.4__alter_table.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `reservation_article`
+    ADD COLUMN `end_time` datetime NOT NULL DEFAULT '2199-12-31T00:00:00';
+
+ALTER TABLE `reservation_article`
+    MODIFY `end_time` datetime NOT NULL;
+
+ALTER TABLE `reservation_article`
+    ADD COLUMN  `introduction` VARCHAR(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL;

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/answer/controller/AnswerController.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/answer/controller/AnswerController.java
@@ -28,7 +28,7 @@ public class AnswerController {
 	private final ChatGptService chatGptService;
 
 	@GetMapping("/questions/{questionId}/answers")
-	public ResponseEntity<ApiResponse<FindAllAnswerResponse>> findAllAnswers(
+	public ResponseEntity<ApiResponse<FindAllAnswerResponse>> findAllAnswer(
 		@PathVariable("questionId") Long questionId) {
 		FindAllAnswerResponse findAllAnswerResponse = answerService.findAllAnswer(questionId);
 		return ResponseEntityFactory.toResponseEntity(ANSWERS_ALL_FOUND, findAllAnswerResponse);

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/answer/dto/FindAnswerResponse.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/answer/dto/FindAnswerResponse.java
@@ -3,17 +3,21 @@ package com.kernelsquare.memberapi.domain.answer.dto;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.kernelsquare.core.util.ImageUtils;
 import com.kernelsquare.core.constants.TimeResponseFormat;
+import com.kernelsquare.core.util.ImageUtils;
 import com.kernelsquare.domainmysql.domain.answer.entity.Answer;
 
+import lombok.Builder;
+
+@Builder
 public record FindAnswerResponse(
 	Long answerId,
+	Long answerMemberId,
 	Long questionId,
 	String content,
 	String rankImageUrl,
 	String memberImageUrl,
-	String createdBy,
+	String memberNickname,
 	Long authorLevel,
 	String answerImageUrl,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = TimeResponseFormat.PATTERN)
@@ -24,19 +28,21 @@ public record FindAnswerResponse(
 	Long voteStatus
 ) {
 	public static FindAnswerResponse from(Answer answer, String rankImageUrl, Long authorLevel, Long voteStatus) {
-		return new FindAnswerResponse(
-			answer.getId(),
-			answer.getQuestion().getId(),
-			answer.getContent(),
-			ImageUtils.makeImageUrl(rankImageUrl),
-			ImageUtils.makeImageUrl(answer.getMember().getImageUrl()),
-			answer.getMember().getNickname(),
-			authorLevel,
-			ImageUtils.makeImageUrl(answer.getImageUrl()),
-			answer.getCreatedDate(),
-			answer.getModifiedDate(),
-			answer.getVoteCount(),
-			voteStatus
-		);
+		return FindAnswerResponse
+			.builder()
+			.answerId(answer.getId())
+			.answerMemberId(answer.getMember().getId())
+			.questionId(answer.getQuestion().getId())
+			.content(answer.getContent())
+			.rankImageUrl(ImageUtils.makeImageUrl(rankImageUrl))
+			.memberImageUrl(ImageUtils.makeImageUrl(answer.getMember().getImageUrl()))
+			.memberNickname(answer.getMember().getNickname())
+			.authorLevel(authorLevel)
+			.answerImageUrl(ImageUtils.makeImageUrl(answer.getImageUrl()))
+			.createdDate(answer.getCreatedDate())
+			.modifiedDate(answer.getModifiedDate())
+			.voteCount(answer.getVoteCount())
+			.voteStatus(voteStatus)
+			.build();
 	}
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/hashtag/dto/UpdateHashtagRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/hashtag/dto/UpdateHashtagRequest.java
@@ -1,10 +1,14 @@
 package com.kernelsquare.memberapi.domain.hashtag.dto;
 
+import com.kernelsquare.core.validation.annotations.BadWordFilter;
+import com.kernelsquare.core.validation.constants.BadWordValidationMessage;
+
 import jakarta.validation.constraints.NotBlank;
 
 public record UpdateHashtagRequest(
 	Long hashtagId,
 	@NotBlank(message = "내용을 필요합니다.")
+	@BadWordFilter(message = BadWordValidationMessage.NO_BAD_WORD_IN_CONTENT)
 	String content,
 	@NotBlank(message = "상태 값이 필요합니다.")
 	String changed

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/dto/UpdateReservationRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation/dto/UpdateReservationRequest.java
@@ -3,8 +3,10 @@ package com.kernelsquare.memberapi.domain.reservation.dto;
 import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record UpdateReservationRequest(
+	@NotNull(message = "예약 ID를 입력해 주세요.")
 	Long reservationId,
 	@NotBlank(message = "시간을 선택해주세요.")
 	LocalDateTime startTime,

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/dto/CreateReservationArticleRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/dto/CreateReservationArticleRequest.java
@@ -3,6 +3,8 @@ package com.kernelsquare.memberapi.domain.reservation_article.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.kernelsquare.core.validation.annotations.BadWordFilter;
+import com.kernelsquare.core.validation.constants.BadWordValidationMessage;
 import com.kernelsquare.domainmysql.domain.member.entity.Member;
 import com.kernelsquare.domainmysql.domain.reservation_article.entity.ReservationArticle;
 
@@ -15,13 +17,20 @@ import lombok.Builder;
 public record CreateReservationArticleRequest(
 	@NotNull(message = "회원 ID를 입력해 주세요.")
 	Long memberId,
-	@NotBlank(message = "예약창 제목을 입력해 주세요.")
-	@Size(min = 5, max = 100, message = "예약창 제목은 5자 이상 100자 이하로 작성해 주세요.")
+	@NotBlank(message = "예약 게시글 제목을 입력해 주세요.")
+	@Size(min = 5, max = 100, message = "예약 게시글 제목은 5자 이상 100자 이하로 작성해 주세요.")
+	@BadWordFilter(message = BadWordValidationMessage.NO_BAD_WORD_IN_CONTENT)
 	String title,
-	@NotBlank(message = "예약창 내용을 입력해 주세요.")
-	@Size(min = 10, max = 1000, message = "예약창 내용은 10자 이상 1000자 이하로 작성해 주세요.")
+	@NotBlank(message = "예약 게시글 내용을 입력해 주세요.")
+	@Size(min = 10, max = 1000, message = "예약 게시글 내용은 10자 이상 1000자 이하로 작성해 주세요.")
+	@BadWordFilter(message = BadWordValidationMessage.NO_BAD_WORD_IN_CONTENT)
 	String content,
+	@NotBlank(message = "예약 게시글 소개를 입력해 주세요.")
+	@Size(min = 10, max = 150, message = "예약 게시글 소개는 10자 이상 150자 이하로 작성해 주세요.")
+	@BadWordFilter(message = BadWordValidationMessage.NO_BAD_WORD_IN_CONTENT)
+	String introduction,
 	@NotNull(message = "최소 빈 리스트로 입력해 주세요.")
+	@BadWordFilter(message = BadWordValidationMessage.NO_BAD_WORD_IN_CONTENT)
 	List<String> hashTags,
 	@NotNull(message = "예약 시간을 입력해 주세요.")
 	List<LocalDateTime> dateTimes
@@ -31,6 +40,7 @@ public record CreateReservationArticleRequest(
 		return ReservationArticle.builder()
 			.title(createReservationArticleRequest.title())
 			.startTime(LocalDateTime.now())
+			.endTime(LocalDateTime.now())
 			.content(createReservationArticleRequest.content())
 			.member(member)
 			.build();

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/dto/FindAllReservationArticleResponse.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/dto/FindAllReservationArticleResponse.java
@@ -10,6 +10,9 @@ import com.kernelsquare.domainmysql.domain.member.entity.Member;
 import com.kernelsquare.domainmysql.domain.reservation_article.entity.ReservationArticle;
 import com.kernelsquare.core.util.ImageUtils;
 
+import lombok.Builder;
+
+@Builder
 public record FindAllReservationArticleResponse(
 	Long articleId,
 	Long memberId,
@@ -18,32 +21,42 @@ public record FindAllReservationArticleResponse(
 	Long level,
 	String levelImageUrl,
 	String title,
+	String introduction,
 	List<String> hashTagList,
+	Long coffeeChatCount,
+	Long availableReservationCount,
+	Long totalReservationCount,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = TimeResponseFormat.PATTERN)
 	LocalDateTime createdDate,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = TimeResponseFormat.PATTERN)
 	LocalDateTime modifiedDate,
-	Boolean articleStatus,
-	Long fullCheck
+	Boolean articleStatus
 ) {
 	public static FindAllReservationArticleResponse of(
 		Member member,
 		ReservationArticle article,
 		Boolean articleStatus,
-		Long fullCheck) {
-		return new FindAllReservationArticleResponse(
-			article.getId(),
-			member.getId(),
-			member.getNickname(),
-			ImageUtils.makeImageUrl(member.getImageUrl()),
-			member.getLevel().getName(),
-			ImageUtils.makeImageUrl(member.getLevel().getImageUrl()),
-			article.getTitle(),
-			article.getHashtagList().stream().map(Hashtag::getContent).toList(),
-			article.getCreatedDate(),
-			article.getModifiedDate(),
-			articleStatus,
-			fullCheck
-		);
+		Long coffeeChatCount,
+		Long availableReservationCount,
+		Long totalReservationCount
+	) {
+		return FindAllReservationArticleResponse
+			.builder()
+			.articleId(article.getId())
+			.memberId(member.getId())
+			.nickname(member.getNickname())
+			.memberImageUrl(ImageUtils.makeImageUrl(member.getImageUrl()))
+			.level(member.getLevel().getName())
+			.levelImageUrl(ImageUtils.makeImageUrl(member.getLevel().getImageUrl()))
+			.title(article.getTitle())
+			.introduction(article.getIntroduction())
+			.hashTagList(article.getHashtagList().stream().map(Hashtag::getContent).toList())
+			.coffeeChatCount(coffeeChatCount)
+			.availableReservationCount(availableReservationCount)
+			.totalReservationCount(totalReservationCount)
+			.createdDate(article.getCreatedDate())
+			.modifiedDate(article.getModifiedDate())
+			.articleStatus(articleStatus)
+			.build();
 	}
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/dto/UpdateReservationArticleRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/dto/UpdateReservationArticleRequest.java
@@ -2,26 +2,34 @@ package com.kernelsquare.memberapi.domain.reservation_article.dto;
 
 import java.util.List;
 
-import com.kernelsquare.domainmysql.domain.member.entity.Member;
-import com.kernelsquare.domainmysql.domain.reservation_article.entity.ReservationArticle;
+import com.kernelsquare.core.validation.annotations.BadWordFilter;
+import com.kernelsquare.core.validation.constants.BadWordValidationMessage;
 import com.kernelsquare.memberapi.domain.hashtag.dto.UpdateHashtagRequest;
-import com.kernelsquare.memberapi.domain.member.dto.UpdateMemberIntroductionRequest;
 import com.kernelsquare.memberapi.domain.reservation.dto.UpdateReservationRequest;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import org.springframework.web.ErrorResponse;
+
 @Builder
 public record UpdateReservationArticleRequest(
+	@NotNull(message = "회원 ID를 입력해 주세요.")
 	Long memberId,
+	@NotNull(message = "게시글 ID를 입력해 주세요.")
 	Long articleId,
 	@NotBlank(message = "예약창 제목을 입력해 주세요.")
 	@Size(min = 5, max = 100, message = "예약창 제목은 5자 이상 100자 이하로 작성해 주세요.")
+	@BadWordFilter(message = BadWordValidationMessage.NO_BAD_WORD_IN_CONTENT)
 	String title,
 	@NotBlank(message = "예약창 내용을 입력해 주세요.")
 	@Size(min = 10, max = 1000, message = "예약창 내용은 10자 이상 1000자 이하로 작성해 주세요.")
+	@BadWordFilter(message = BadWordValidationMessage.NO_BAD_WORD_IN_CONTENT)
 	String content,
+	@NotBlank(message = "예약 게시글 소개를 입력해 주세요.")
+	@Size(min = 10, max = 150, message = "예약 게시글 소개는 10자 이상 150자 이하로 작성해 주세요.")
+	@BadWordFilter(message = BadWordValidationMessage.NO_BAD_WORD_IN_CONTENT)
+	String introduction,
 	List<UpdateHashtagRequest> changeHashtags,
 	List<UpdateReservationRequest> changeReservations
 ) {

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleService.java
@@ -1,5 +1,21 @@
 package com.kernelsquare.memberapi.domain.reservation_article.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.kernelsquare.core.common_response.error.code.ReservationArticleErrorCode;
 import com.kernelsquare.core.common_response.error.exception.BusinessException;
 import com.kernelsquare.core.dto.PageResponse;
@@ -18,17 +34,13 @@ import com.kernelsquare.memberapi.domain.hashtag.dto.FindHashtagResponse;
 import com.kernelsquare.memberapi.domain.hashtag.dto.UpdateHashtagRequest;
 import com.kernelsquare.memberapi.domain.reservation.dto.FindReservationResponse;
 import com.kernelsquare.memberapi.domain.reservation.dto.UpdateReservationRequest;
-import com.kernelsquare.memberapi.domain.reservation_article.dto.*;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import com.kernelsquare.memberapi.domain.reservation_article.dto.CreateReservationArticleRequest;
+import com.kernelsquare.memberapi.domain.reservation_article.dto.CreateReservationArticleResponse;
+import com.kernelsquare.memberapi.domain.reservation_article.dto.FindAllReservationArticleResponse;
+import com.kernelsquare.memberapi.domain.reservation_article.dto.FindReservationArticleResponse;
+import com.kernelsquare.memberapi.domain.reservation_article.dto.UpdateReservationArticleRequest;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -50,8 +62,8 @@ public class ReservationArticleService {
 
 		// 예약창이 있는 경우 생성 불가 (1인 1예약창 정책)
 		if (reservationRepository.existsByMemberIdAndEndTimeAfter(
-				member.getId(),
-				LocalDateTime.now()
+			member.getId(),
+			LocalDateTime.now()
 		)) {
 			throw new BusinessException(ReservationArticleErrorCode.TOO_MANY_RESERVATION_ARTICLE);
 		}
@@ -108,7 +120,7 @@ public class ReservationArticleService {
 
 		// 예약 생성 기한 체크 로직 (7일 이후, 한달 이전)
 		if (!(startTime.isAfter(currentDateTime.plusDays(6)) && startTime.isBefore(
-				currentDateTime.plusMonths(1)))) {
+			currentDateTime.plusMonths(1)))) {
 			throw new BusinessException(ReservationArticleErrorCode.RESERVATION_PERIOD_LIMIT);
 		}
 
@@ -136,9 +148,11 @@ public class ReservationArticleService {
 
 		List<FindAllReservationArticleResponse> responsePages = pages.getContent().stream()
 			.map(article -> {
-				Long coffeeChatCount = reservationArticleRepository.countAllByMemberIdAndEndTimeBefore(article.getMember().getId(),
+				Long coffeeChatCount = reservationArticleRepository.countAllByMemberIdAndEndTimeBefore(
+					article.getMember().getId(),
 					LocalDateTime.now());
-				Long availableReservationCount = reservationRepository.countByReservationArticleIdAndMemberIdIsNull(article.getId());
+				Long availableReservationCount = reservationRepository.countByReservationArticleIdAndMemberIdIsNull(
+					article.getId());
 				Long totalReservationCount = reservationRepository.countAllByReservationArticleId(article.getId());
 				Boolean articleStatus = checkIfReservationWithinTheAvailablePeriod(article.getStartTime());
 				return FindAllReservationArticleResponse.of(
@@ -147,7 +161,7 @@ public class ReservationArticleService {
 					articleStatus,
 					coffeeChatCount,
 					availableReservationCount
-					,totalReservationCount
+					, totalReservationCount
 				);
 			})
 			.toList();
@@ -199,7 +213,8 @@ public class ReservationArticleService {
 		}
 
 		// 제목이나 내용은 ReservationArticle 의 update 로 변경
-		reservationArticle.update(updateReservationArticleRequest.title(), updateReservationArticleRequest.content());
+		reservationArticle.update(updateReservationArticleRequest.title(), updateReservationArticleRequest.content(),
+			updateReservationArticleRequest.introduction());
 
 		// changehashtags 가 존재한다면 아래 로직
 		if (updateReservationArticleRequest.changeHashtags() != null) {
@@ -324,7 +339,7 @@ public class ReservationArticleService {
 			}
 		}
 	}
-	
+
 	@Transactional
 	public void deleteReservationArticle(Long postId) {
 		ReservationArticle reservationArticle = reservationArticleRepository.findById(postId)

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/answer/controller/AnswerControllerTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/answer/controller/AnswerControllerTest.java
@@ -57,6 +57,7 @@ public class AnswerControllerTest {
 	private final Long testQuestionId = 1L;
 	private final Question testQuestion = Question
 		.builder()
+		.id(testQuestionId)
 		.title("Test Question")
 		.content("Test Content")
 		.imageUrl("S3:TestImage")
@@ -64,6 +65,7 @@ public class AnswerControllerTest {
 		.build();
 	private final Member testMember = Member
 		.builder()
+		.id(1L)
 		.nickname("hongjugwang")
 		.email("jugwang@naver.com")
 		.password("hashedPassword")
@@ -78,6 +80,7 @@ public class AnswerControllerTest {
 		.build();
 	private final Answer testAnswer = Answer
 		.builder()
+		.id(1L)
 		.content("Test Answer Content")
 		.voteCount(10L)
 		.imageUrl("s3:AnswerImageURL")
@@ -92,6 +95,7 @@ public class AnswerControllerTest {
 		.build();
 	private final FindAnswerResponse findAnswerResponse = new FindAnswerResponse(
 		testAnswer.getId(),
+		testAnswer.getMember().getId(),
 		testQuestion.getId(),
 		testAnswer.getContent(),
 		"s3:RankURL",
@@ -100,7 +104,7 @@ public class AnswerControllerTest {
 		testMember.getLevel().getName(),
 		testAnswer.getImageUrl(),
 		LocalDateTime.now(),
-		null,
+		LocalDateTime.now(),
 		testAnswer.getVoteCount(),
 		Long.valueOf(testMemberAnswerVote.getStatus())
 	);
@@ -154,26 +158,32 @@ public class AnswerControllerTest {
 				responseFields(
 					fieldWithPath("data").description("응답"),
 					fieldWithPath("msg").type(JsonFieldType.STRING).description("응답 메시지"),
-					fieldWithPath("code").description("The status code of the response."),
-					fieldWithPath("data.answer_responses").description("Array containing answer responses."),
-					fieldWithPath("data.answer_responses[].answer_id").description("The answer ID."),
-					fieldWithPath("data.answer_responses[].question_id").description("The question ID."),
-					fieldWithPath("data.answer_responses[].content").description("The content of the answer."),
-					fieldWithPath("data.answer_responses[].rank_image_url").description("The URL of the rank image."),
-					fieldWithPath("data.answer_responses[].member_image_url").description(
-						"The URL of the member image."),
-					fieldWithPath("data.answer_responses[].created_by").description("The username of the creator."),
-					fieldWithPath("data.answer_responses[].author_level").description("The author level."),
-					fieldWithPath("data.answer_responses[].answer_image_url").description(
-						"The URL of the answer image."),
-					fieldWithPath("data.answer_responses[].created_date").description(
-						"The creation date of the answer."),
-					fieldWithPath("data.answer_responses[].modified_date").description(
-						"The modification date of the answer."),
-					fieldWithPath("data.answer_responses[].vote_count").description(
-						"The number of votes for the answer."),
-					fieldWithPath("data.answer_responses[].vote_status").description(
-						"The vote status of the answer."))));
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("커스텀 응답 코드"),
+					fieldWithPath("data.answer_responses").type(JsonFieldType.ARRAY).description("답변 리스트"),
+					fieldWithPath("data.answer_responses[].answer_id").type(JsonFieldType.NUMBER).description("답변 아이디"),
+					fieldWithPath("data.answer_responses[].answer_member_id").type(JsonFieldType.NUMBER)
+						.description("답변 작성자 아이디"),
+					fieldWithPath("data.answer_responses[].member_nickname").type(JsonFieldType.STRING)
+						.description("응답 메시지"),
+					fieldWithPath("data.answer_responses[].question_id").type(JsonFieldType.NUMBER)
+						.description("질문 아이디"),
+					fieldWithPath("data.answer_responses[].content").type(JsonFieldType.STRING).description("내용"),
+					fieldWithPath("data.answer_responses[].rank_image_url").type(JsonFieldType.STRING)
+						.description("랭크 이미지 주소"),
+					fieldWithPath("data.answer_responses[].member_image_url").type(JsonFieldType.STRING).description(
+						"회원 프로필 사진 주소"),
+					fieldWithPath("data.answer_responses[].author_level").type(JsonFieldType.NUMBER)
+						.description("답변 작성자 레벨"),
+					fieldWithPath("data.answer_responses[].answer_image_url").type(JsonFieldType.STRING).description(
+						"답변 이미지 주소"),
+					fieldWithPath("data.answer_responses[].created_date").type(JsonFieldType.STRING).description(
+						"답변 생성일"),
+					fieldWithPath("data.answer_responses[].modified_date").type(JsonFieldType.STRING).description(
+						"답변 수정일"),
+					fieldWithPath("data.answer_responses[].vote_count").type(JsonFieldType.NUMBER)
+						.description("답변 투표수"),
+					fieldWithPath("data.answer_responses[].vote_status").type(JsonFieldType.NUMBER).description(
+						"투표 상태"))));
 
 		//verify
 		verify(answerService, times(1)).findAllAnswer(testQuestionId);

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/controller/ReservationArticleControllerTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/controller/ReservationArticleControllerTest.java
@@ -54,6 +54,7 @@ class ReservationArticleControllerTest {
 		return ReservationArticle.builder()
 			.id(id)
 			.title("testplz")
+			.introduction("dawfgawgawgawgawg")
 			.content("ahahahahahhhh")
 			.build();
 	}
@@ -96,6 +97,7 @@ class ReservationArticleControllerTest {
 		CreateReservationArticleRequest createReservationArticleRequest =
 			new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(),
 				reservationArticle.getContent(),
+				reservationArticle.getIntroduction(),
 				List.of(hashtag.getContent()), List.of(LocalDateTime.now(), LocalDateTime.now().plusDays(2)));
 
 		objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
@@ -161,9 +163,9 @@ class ReservationArticleControllerTest {
 			.build();
 
 		FindAllReservationArticleResponse findAllReservationArticleResponse1 = FindAllReservationArticleResponse.of(
-			member, reservationArticle1, true, 1L);
+			member, reservationArticle1, true, 1L, 1L, 1L);
 		FindAllReservationArticleResponse findAllReservationArticleResponse2 = FindAllReservationArticleResponse.of(
-			member, reservationArticle2, false, 0L);
+			member, reservationArticle2, false, 0L, 1L, 1L);
 
 		List<FindAllReservationArticleResponse> responsePages = List.of(findAllReservationArticleResponse1,
 			findAllReservationArticleResponse2);

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/dto/ReservationArticleRequestDtoTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/dto/ReservationArticleRequestDtoTest.java
@@ -25,6 +25,9 @@ class ReservationArticleRequestDtoTest {
 		CreateReservationArticleRequest createReservationArticleRequest = CreateReservationArticleRequest.builder()
 			.title("")
 			.content("")
+			.introduction("")
+			.dateTimes(List.of())
+			.hashTags(List.of())
 			.build();
 
 		Set<ConstraintViolation<CreateReservationArticleRequest>> violations = validator.validate(
@@ -32,22 +35,29 @@ class ReservationArticleRequestDtoTest {
 		Set<String> msgList = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
 
 		//then
-		assertThat(msgList).isEqualTo(Set.of("회원 ID를 입력해 주세요.", "예약창 제목을 입력해 주세요.", "예약창 내용을 입력해 주세요.",
-				"최소 빈 리스트로 입력해 주세요.", "예약 시간을 입력해 주세요.", "예약창 제목은 5자 이상 100자 이하로 작성해 주세요.", "예약창 내용은 10자 이상 1000자 이하로 작성해 주세요."));
+		assertThat(msgList).isEqualTo(Set.of("예약 게시글 소개는 10자 이상 150자 이하로 작성해 주세요.",
+			"예약 게시글 제목은 5자 이상 100자 이하로 작성해 주세요.",
+			"예약 게시글 소개를 입력해 주세요.",
+			"예약 게시글 내용을 입력해 주세요.",
+			"예약 게시글 내용은 10자 이상 1000자 이하로 작성해 주세요.",
+			"회원 ID를 입력해 주세요.",
+			"예약 게시글 제목을 입력해 주세요."));
 	}
 
 	@Test
 	@DisplayName("예약창 생성 요청 검증 성공 테스트 - Size")
 	void whenCreateReservationArticleSizeExceedsLimit_thenValidationSucceeds() {
 		CreateReservationArticleRequest createReservationArticleRequest = CreateReservationArticleRequest.builder()
-				.memberId(1L)
-				.title("a".repeat(100))
-				.content("a".repeat(1000))
-				.hashTags(List.of())
-				.dateTimes(List.of())
-				.build();
+			.memberId(1L)
+			.title("a".repeat(100))
+			.introduction("a".repeat(100))
+			.content("a".repeat(1000))
+			.hashTags(List.of())
+			.dateTimes(List.of())
+			.build();
 
-		Set<ConstraintViolation<CreateReservationArticleRequest>> violations = validator.validate(createReservationArticleRequest);
+		Set<ConstraintViolation<CreateReservationArticleRequest>> violations = validator.validate(
+			createReservationArticleRequest);
 		Set<String> msgList = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
 
 		assertThat(msgList).isEqualTo(Set.of());
@@ -57,63 +67,84 @@ class ReservationArticleRequestDtoTest {
 	@DisplayName("예약창 생성 요청 검증 실패 테스트 - MaxSize")
 	void whenCreateReservationArticleSizeExceedsMaxLimit_thenValidationFails() {
 		CreateReservationArticleRequest createReservationArticleRequest = CreateReservationArticleRequest.builder()
-				.memberId(1L)
-				.title("a".repeat(101))
-				.content("a".repeat(1001))
-				.hashTags(List.of())
-				.dateTimes(List.of())
-				.build();
+			.memberId(1L)
+			.title("a".repeat(101))
+			.introduction("a".repeat(101))
+			.content("a".repeat(1001))
+			.hashTags(List.of())
+			.dateTimes(List.of())
+			.build();
 
-		Set<ConstraintViolation<CreateReservationArticleRequest>> violations = validator.validate(createReservationArticleRequest);
+		Set<ConstraintViolation<CreateReservationArticleRequest>> violations = validator.validate(
+			createReservationArticleRequest);
 		Set<String> msgList = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
 
-		assertThat(msgList).isEqualTo(Set.of("예약창 제목은 5자 이상 100자 이하로 작성해 주세요.", "예약창 내용은 10자 이상 1000자 이하로 작성해 주세요."));
+		assertThat(msgList).isEqualTo(
+			Set.of("예약 게시글 제목은 5자 이상 100자 이하로 작성해 주세요.", "예약 게시글 내용은 10자 이상 1000자 이하로 작성해 주세요."));
 	}
 
 	@Test
 	@DisplayName("예약창 생성 요청 검증 실패 테스트 - MinSize")
 	void whenCreateReservationArticleSizeExceedsMinLimit_thenValidationFails() {
 		CreateReservationArticleRequest createReservationArticleRequest = CreateReservationArticleRequest.builder()
-				.memberId(1L)
-				.title("a")
-				.content("a")
-				.hashTags(List.of())
-				.dateTimes(List.of())
-				.build();
+			.memberId(1L)
+			.title("a")
+			.introduction("")
+			.content("a")
+			.hashTags(List.of())
+			.dateTimes(List.of())
+			.build();
 
-		Set<ConstraintViolation<CreateReservationArticleRequest>> violations = validator.validate(createReservationArticleRequest);
+		Set<ConstraintViolation<CreateReservationArticleRequest>> violations = validator.validate(
+			createReservationArticleRequest);
 		Set<String> msgList = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
 
-		assertThat(msgList).isEqualTo(Set.of("예약창 제목은 5자 이상 100자 이하로 작성해 주세요.", "예약창 내용은 10자 이상 1000자 이하로 작성해 주세요."));
+		assertThat(msgList).isEqualTo(Set.of("예약 게시글 소개는 10자 이상 150자 이하로 작성해 주세요.",
+			"예약 게시글 제목은 5자 이상 100자 이하로 작성해 주세요.",
+			"예약 게시글 소개를 입력해 주세요.",
+			"예약 게시글 내용은 10자 이상 1000자 이하로 작성해 주세요."));
 	}
 
 	@Test
 	@DisplayName("예약창 수정 요청 검증 테스트 - NotNull, NotBlank")
 	void whenUpdateReservationArticleIsNotBlank_thenValidationFails() {
 		UpdateReservationArticleRequest updateReservationArticleRequest = UpdateReservationArticleRequest.builder()
-				.title("")
-				.content("")
-				.build();
+			.title("")
+			.introduction("")
+			.content("")
+			.changeHashtags(List.of())
+			.build();
 
 		Set<ConstraintViolation<UpdateReservationArticleRequest>> violations = validator.validate(
-				updateReservationArticleRequest);
+			updateReservationArticleRequest);
 		Set<String> msgList = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
 
 		//then
-		assertThat(msgList).isEqualTo(Set.of("예약창 제목을 입력해 주세요.", "예약창 내용을 입력해 주세요.",
-				"예약창 제목은 5자 이상 100자 이하로 작성해 주세요.", "예약창 내용은 10자 이상 1000자 이하로 작성해 주세요."));
+		assertThat(msgList).isEqualTo(Set.of("예약 게시글 소개는 10자 이상 150자 이하로 작성해 주세요.",
+			"예약창 제목은 5자 이상 100자 이하로 작성해 주세요.",
+			"예약창 내용을 입력해 주세요.",
+			"게시글 ID를 입력해 주세요.",
+			"예약 게시글 소개를 입력해 주세요.",
+			"예약창 내용은 10자 이상 1000자 이하로 작성해 주세요.",
+			"예약창 제목을 입력해 주세요.",
+			"회원 ID를 입력해 주세요."));
 	}
 
 	@Test
 	@DisplayName("예약창 수정 요청 검증 성공 테스트 - Size")
 	void whenUpdateReservationArticleSizeExceedsLimit_thenValidationSucceeds() {
 		UpdateReservationArticleRequest updateReservationArticleRequest = UpdateReservationArticleRequest.builder()
-				.memberId(1L)
-				.title("a".repeat(100))
-				.content("a".repeat(1000))
-				.build();
+			.memberId(1L)
+			.articleId(1L)
+			.introduction("a".repeat(100))
+			.title("a".repeat(100))
+			.content("a".repeat(1000))
+			.changeReservations(List.of())
+			.changeHashtags(List.of())
+			.build();
 
-		Set<ConstraintViolation<UpdateReservationArticleRequest>> violations = validator.validate(updateReservationArticleRequest);
+		Set<ConstraintViolation<UpdateReservationArticleRequest>> violations = validator.validate(
+			updateReservationArticleRequest);
 		Set<String> msgList = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
 
 		assertThat(msgList).isEqualTo(Set.of());
@@ -123,29 +154,42 @@ class ReservationArticleRequestDtoTest {
 	@DisplayName("예약창 수정 요청 검증 실패 테스트 - MaxSize")
 	void whenUpdateReservationArticleSizeExceedsMaxLimit_thenValidationFails() {
 		UpdateReservationArticleRequest updateReservationArticleRequest = UpdateReservationArticleRequest.builder()
-				.memberId(1L)
-				.title("a".repeat(101))
-				.content("a".repeat(1001))
-				.build();
+			.memberId(1L)
+			.introduction("a".repeat(101))
+			.changeReservations(List.of())
+			.changeHashtags(List.of())
+			.title("a".repeat(101))
+			.content("a".repeat(1001))
+			.build();
 
-		Set<ConstraintViolation<UpdateReservationArticleRequest>> violations = validator.validate(updateReservationArticleRequest);
+		Set<ConstraintViolation<UpdateReservationArticleRequest>> violations = validator.validate(
+			updateReservationArticleRequest);
 		Set<String> msgList = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
 
-		assertThat(msgList).isEqualTo(Set.of("예약창 제목은 5자 이상 100자 이하로 작성해 주세요.", "예약창 내용은 10자 이상 1000자 이하로 작성해 주세요."));
+		assertThat(msgList).isEqualTo(Set.of("예약창 제목은 5자 이상 100자 이하로 작성해 주세요.",
+			"게시글 ID를 입력해 주세요.",
+			"예약창 내용은 10자 이상 1000자 이하로 작성해 주세요."));
 	}
 
 	@Test
 	@DisplayName("예약창 수정 요청 검증 실패 테스트 - MinSize")
 	void whenUpdateReservationArticleSizeExceedsMinLimit_thenValidationFails() {
 		UpdateReservationArticleRequest updateReservationArticleRequest = UpdateReservationArticleRequest.builder()
-				.memberId(1L)
-				.title("a")
-				.content("a")
-				.build();
+			.memberId(1L)
+			.title("a")
+			.introduction("a")
+			.content("a")
+			.changeHashtags(List.of())
+			.changeReservations(List.of())
+			.build();
 
-		Set<ConstraintViolation<UpdateReservationArticleRequest>> violations = validator.validate(updateReservationArticleRequest);
+		Set<ConstraintViolation<UpdateReservationArticleRequest>> violations = validator.validate(
+			updateReservationArticleRequest);
 		Set<String> msgList = violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
 
-		assertThat(msgList).isEqualTo(Set.of("예약창 제목은 5자 이상 100자 이하로 작성해 주세요.", "예약창 내용은 10자 이상 1000자 이하로 작성해 주세요."));
+		assertThat(msgList).isEqualTo(Set.of("예약 게시글 소개는 10자 이상 150자 이하로 작성해 주세요.",
+			"예약창 제목은 5자 이상 100자 이하로 작성해 주세요.",
+			"게시글 ID를 입력해 주세요.",
+			"예약창 내용은 10자 이상 1000자 이하로 작성해 주세요."));
 	}
 }

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/reservation_article/service/ReservationArticleServiceTest.java
@@ -8,8 +8,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import com.kernelsquare.core.common_response.error.code.ReservationArticleErrorCode;
-import com.kernelsquare.core.common_response.error.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +19,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import com.kernelsquare.core.common_response.error.code.ReservationArticleErrorCode;
+import com.kernelsquare.core.common_response.error.exception.BusinessException;
 import com.kernelsquare.core.dto.PageResponse;
 import com.kernelsquare.core.type.AuthorityType;
 import com.kernelsquare.domainmysql.domain.authority.entity.Authority;
@@ -96,9 +96,9 @@ class ReservationArticleServiceTest {
 
 	private Reservation createTestReservationStartTime(ChatRoom chatRoom, LocalDateTime startTime) {
 		return Reservation.builder()
-				.chatRoom(chatRoom)
-				.startTime(startTime)
-				.build();
+			.chatRoom(chatRoom)
+			.startTime(startTime)
+			.build();
 	}
 
 	private Member createTestMember() {
@@ -158,12 +158,14 @@ class ReservationArticleServiceTest {
 		CreateReservationArticleRequest createReservationArticleRequest =
 			new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(),
 				reservationArticle.getContent(),
+				reservationArticle.getIntroduction(),
 				List.of(hashtag.getContent()),
 				List.of(LocalDateTime.now().plusDays(7), LocalDateTime.now().plusDays(8)));
 
 		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
-		given(reservationRepository.existsByMemberIdAndEndTimeAfter(eq(member.getId()), any(LocalDateTime.class))).willReturn(
-				false
+		given(reservationRepository.existsByMemberIdAndEndTimeAfter(eq(member.getId()),
+			any(LocalDateTime.class))).willReturn(
+			false
 		);
 		given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
 
@@ -202,14 +204,15 @@ class ReservationArticleServiceTest {
 		Hashtag hashtag = createTestHashtag();
 
 		CreateReservationArticleRequest createReservationArticleRequest =
-				new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(),
-						reservationArticle.getContent(),
-						List.of(hashtag.getContent()),
-						List.of(LocalDateTime.now().plusDays(40L), LocalDateTime.now().plusDays(41L)));
+			new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(),
+				reservationArticle.getContent(),
+				reservationArticle.getIntroduction(),
+				List.of(hashtag.getContent()),
+				List.of(LocalDateTime.now().plusDays(40L), LocalDateTime.now().plusDays(41L)));
 
 		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
 		given(reservationRepository.existsByMemberIdAndEndTimeAfter(anyLong(), any(LocalDateTime.class))).willReturn(
-				false
+			false
 		);
 		given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
 
@@ -217,10 +220,10 @@ class ReservationArticleServiceTest {
 
 		// Then
 		assertThatThrownBy(() ->
-				reservationArticleService.createReservationArticle(createReservationArticleRequest))
-				.isExactlyInstanceOf(BusinessException.class)
-				.extracting("errorCode")
-				.isEqualTo(ReservationArticleErrorCode.RESERVATION_PERIOD_LIMIT);
+			reservationArticleService.createReservationArticle(createReservationArticleRequest))
+			.isExactlyInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReservationArticleErrorCode.RESERVATION_PERIOD_LIMIT);
 
 		// Verify
 		verify(memberRepository, times(1)).findById(anyLong());
@@ -249,14 +252,15 @@ class ReservationArticleServiceTest {
 		Hashtag hashtag = createTestHashtag();
 
 		CreateReservationArticleRequest createReservationArticleRequest =
-				new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(),
-						reservationArticle.getContent(),
-						List.of(hashtag.getContent()),
-						List.of(LocalDateTime.now().plusDays(7L), LocalDateTime.now().plusDays(11L).plusMinutes(30L)));
+			new CreateReservationArticleRequest(member.getId(), reservationArticle.getTitle(),
+				reservationArticle.getContent(),
+				reservationArticle.getIntroduction(),
+				List.of(hashtag.getContent()),
+				List.of(LocalDateTime.now().plusDays(7L), LocalDateTime.now().plusDays(11L).plusMinutes(30L)));
 
 		given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
 		given(reservationRepository.existsByMemberIdAndEndTimeAfter(anyLong(), any(LocalDateTime.class))).willReturn(
-				false
+			false
 		);
 		given(reservationArticleRepository.save(any(ReservationArticle.class))).willReturn(reservationArticle);
 
@@ -264,17 +268,16 @@ class ReservationArticleServiceTest {
 
 		// Then
 		assertThatThrownBy(() ->
-				reservationArticleService.createReservationArticle(createReservationArticleRequest))
-				.isExactlyInstanceOf(BusinessException.class)
-				.extracting("errorCode")
-				.isEqualTo(ReservationArticleErrorCode.RESERVATION_TIME_LIMIT);
+			reservationArticleService.createReservationArticle(createReservationArticleRequest))
+			.isExactlyInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ReservationArticleErrorCode.RESERVATION_TIME_LIMIT);
 
 		// Verify
 		verify(memberRepository, times(1)).findById(anyLong());
 		verify(reservationRepository, times(1)).existsByMemberIdAndEndTimeAfter(anyLong(), any(LocalDateTime.class));
 		verify(reservationArticleRepository, times(1)).save(any(ReservationArticle.class));
 	}
-
 
 	@Test
 	@DisplayName("모든 예약창 조회 테스트")


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close #330

## 개요
> 변경 사항에 대해 간단하게 작성해주세요. 무엇을 왜 수정했는지 설명해주세요.
UI / UX 수정 요청에 따른 API 변경 사항 반영

## 상세 내용
- ``ReservationArticle`` 에 ``introduction``과 ``end_time`` 컬럼 추가
- ``CreateReservationArticleRequest``, ``UpdateReservationArticleRequest``에 유효성 검증 추가 (비속어 필터링) 및 추가된 엔티티 및 컬럼에 대한 수정할 수 있도록 필드 추가
- ``FindAllReservationArticleResponse`` 값 추가 ( + 멘토의 기존 멘토링 횟수, 이미 마감되거나 시간이 지난 글 보이지 않게 수정, 현재 신청 가능한 예약의 개수, 전체 예약의 개수, 멘토링에 대한 설명 글)
- ``FindAllAnswerResponse`` 에 회원 ID 추가, 답변 프로필 눌렀을 때 회원의 마이 페이지로 이동하기 위함
- ``@BadWordFilter``가 ``String`` 및 ``List<String>`` 을 모두 처리할 수 있도록 내부 구현 수정