### PR TITLE
[setting] Redis, Kafka, MongoDB를 하나의 서버로 분리

### DIFF
--- a/member-api/src/main/java/com/kernelsquare/memberapi/common/config/KafkaConsumerConfig.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/common/config/KafkaConsumerConfig.java
@@ -3,6 +3,7 @@ package com.kernelsquare.memberapi.common.config;
 import com.kernelsquare.memberapi.domain.coffeechat.dto.ChatMessageRequest;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -17,11 +18,13 @@ import java.util.Map;
 @Configuration
 @EnableKafka
 public class KafkaConsumerConfig {
+	@Value("${kafka.url}")
+	private String url;
 	@Bean
 	public ConsumerFactory<String, ChatMessageRequest> consumerFactory() {
 		Map<String, Object> config = new HashMap<>();
 
-		config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
 		config.put(ConsumerConfig.GROUP_ID_CONFIG, "coffeechat");
 		config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 		config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);

--- a/member-api/src/main/java/com/kernelsquare/memberapi/common/config/KafkaProducerConfig.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/common/config/KafkaProducerConfig.java
@@ -2,6 +2,7 @@ package com.kernelsquare.memberapi.common.config;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -16,10 +17,12 @@ import java.util.Map;
 @Configuration
 @EnableKafka
 public class KafkaProducerConfig {
+	@Value("${kafka.url}")
+	private String url;
 	@Bean
 	public ProducerFactory<String, Object> producerFactory() {
 		Map<String, Object> config = new HashMap<>();
-		config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
 		config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 		config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
 		return new DefaultKafkaProducerFactory<>(config);

--- a/member-api/src/main/java/com/kernelsquare/memberapi/common/config/RedisConfig.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/common/config/RedisConfig.java
@@ -17,9 +17,15 @@ public class RedisConfig {
 	@Value("${spring.redis.serialization.class-property-type-name}")
 	String classPropertyTypeName;
 
+	@Value("${spring.redis.host}")
+	private String host;
+
+	@Value("${spring.redis.port}")
+	private int port;
+
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory();
+		return new LettuceConnectionFactory(host, port);
 	}
 
 	@Bean

--- a/member-api/src/main/resources/application.yml
+++ b/member-api/src/main/resources/application.yml
@@ -37,6 +37,8 @@ spring:
   redis:
     serialization:
       class-property-type-name: RefreshToken.class
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
   data:
     mongodb:
@@ -78,6 +80,9 @@ cloud:
     credentials:
       accessKey: ${AWS_ACCESS_KEY}
       secretKey: ${AWS_ACCESS_SECRET}
+
+kafka:
+  url: ${KAFKA_URL}
 
 custom:
   domain:


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #359 

## 개요
> 추후 무중단 배포가 구현이 된다면 스프링부트 서버는 2개 이상이되고 그 서버들이 하나의 데이터소스를 바라보고 있어야하기 때문에 데이터소스인 Redis, Kafka, MongoDB를 따로 분리하기 위함

## 상세 내용
- EC2 ubuntu t2.micro 인스턴스를 kernelsquare_datahub의 이름으로 생성
- 서버 접속은 pem 키로만 들어갈 수 있음(pem 키 요청하시면 드리겠습니다.)
- docker로  Redis, Zookeeper, Kafka, MongoDB 설치
- 메모리 부족으로 Kafka 동작하질 않아서 swapfile 8GB 생성
- RedisConfig에 `@Value`으로 받는 url과 port 추가(그에 따라 application.yml에 속성을 추가하여 환경변수 넣음)
- KafkaProducerConfig와 KafkaConsumerConfig에 `@Value`으로 받는 url 추가(그에 따라 application.yml에 속성을 추가하여 환경변수 넣음)
- MONGO_URI 및 MONGO_TEST_URI 환경변수 값 변경(슬랙 참고)
- 로컬에서 연결하여 테스트