### PR TITLE
[setting] get-server-information 호출 시 값나오게 수정

### DIFF
--- a/member-api/src/main/java/com/kernelsquare/memberapi/common/server/ServerController.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/common/server/ServerController.java
@@ -10,9 +10,9 @@ import java.util.Map;
 
 @RestController
 public class ServerController {
-    @Value("${:member-api.serverName}") // application.yml의 값들을 매핑시킴
+    @Value("${serverName}") // application.yml의 값들을 매핑시킴
     private String serverName;
-    @Value("${:domain-mysql.dbInfo}")
+    @Value("${dbInfo}")
     private String dbInfo;
     @Value("${server.env}")
     private String env;

--- a/member-api/src/main/resources/application.yml
+++ b/member-api/src/main/resources/application.yml
@@ -10,6 +10,10 @@ server:
   env: develop
   port: 8501
 
+dbInfo: rds
+
+serverName: kernelsquare-develop
+
 ---
 
 spring:
@@ -137,6 +141,8 @@ spring:
       on-profile: prod2-server
 
 serverName: kernelsquare-prod2
+
+dbInfo: rds
 
 server:
   port: 8502


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: 

## 개요
> get-server-information 호출 시 값나오게 수정
## 상세 내용
- 모듈 명시하면 blue, green 이 나오지 않는 현상 발생
- 모듈 명시 제거하고 local 을 develop 으로 사용하기로 함(VM 옵션 추가해서 local 로 입력)
`-Dspring.profiles.active=local -Dserver.env=develop`
- domain-mysql 의 프로퍼티 값을 ServerController 에서 가져오는 방법을 찾지 못해 member-api application에 dbInfo 추가