### PR TITLE
[fix] 깃허브 시크릿 변수 이름 변경

### DIFF
--- a/member-api/src/main/resources/application.yml
+++ b/member-api/src/main/resources/application.yml
@@ -75,8 +75,8 @@ spring:
       client:
         registration:
           github:
-            client-id: ${GITHUB_SOCIAL_CLIENT_ID}
-            client-secret: ${GITHUB_SOCIAL_CLIENT_SECRET}
+            client-id: ${SOCIAL_GITHUB_CLIENT_ID}
+            client-secret: ${SOCIAL_GITHUB_CLIENT_SECRET}
             redirect-uri: http://localhost:8501/login/oauth2/code/github
             scope:
               - user:email


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: 

## 개요
> 시크릿 변수 명을 GITHUB 로 시작할 수 없음

## 상세 내용
- GITHUB_SOCIAL_CLIENT_ID -> SOCIAL_GITHUB_CLIENT_ID
- GITHUB_SOCIAL_CLIENT_SECRET -> SOCIAL_GITHUB_CLIENT_SECRET