### PR TITLE
[feat] 닉네임 변경 기능 추가

### DIFF
--- a/core/src/main/java/com/kernelsquare/core/common_response/error/code/MemberErrorCode.java
+++ b/core/src/main/java/com/kernelsquare/core/common_response/error/code/MemberErrorCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, MemberServiceStatus.MEMBER_NOT_FOUND, "존재하지 않는 회원입니다."),
-	AUTHORITY_TYPE_NOT_VALID(HttpStatus.BAD_REQUEST, MemberServiceStatus.AUTHORITY_TYPE_NOT_VALID, "유효하지 않는 권한 타입입니다.");
+	AUTHORITY_TYPE_NOT_VALID(HttpStatus.BAD_REQUEST, MemberServiceStatus.AUTHORITY_TYPE_NOT_VALID, "유효하지 않는 권한 타입입니다."),
+	ALREADY_SAVED_NICKNAME(HttpStatus.CONFLICT, MemberServiceStatus.ALREADY_SAVED_NICKNAME, "사용 중인 닉네임입니다.");
 
 	private final HttpStatus httpStatus;
 	private final ServiceStatus serviceStatus;

--- a/core/src/main/java/com/kernelsquare/core/common_response/service/code/MemberServiceStatus.java
+++ b/core/src/main/java/com/kernelsquare/core/common_response/service/code/MemberServiceStatus.java
@@ -7,6 +7,7 @@ public enum MemberServiceStatus implements ServiceStatus {
 	//error
 	MEMBER_NOT_FOUND(1201),
 	AUTHORITY_TYPE_NOT_VALID(1202),
+	ALREADY_SAVED_NICKNAME(1203),
 
 	//success
 	MEMBER_FOUND(1240),

--- a/member-api/build.gradle
+++ b/member-api/build.gradle
@@ -120,4 +120,8 @@ tasks.build {
     dependsOn(tasks.asciidoctor, tasks.copyHTML)
 }
 
+tasks.named('jar') {
+    enabled = false
+}
+
 

--- a/member-api/src/docs/asciidoc/member-api-index.adoc
+++ b/member-api/src/docs/asciidoc/member-api-index.adoc
@@ -23,5 +23,6 @@ endif::[]
 |link:member-profile-updated.html[회원 프로필 사진 수정] |PUT |/api/v1/members/{memberId}/profile
 |link:member-introduction-updated.html[회원 소개 수정] |PUT |/api/v1/members/{memberId}/introduction
 |link:member-password-updated.html[회원 비밀번호 수정] |PUT |/api/v1/members/{memberId}/password
+|link:member-nickname-updated.html[회원 닉네임 수정] |PUT |/api/v1/members/nickname
 |link:member-found.html[회원 조회] |GET |/api/v1/members/{memberId}
 |link:member-deleted.html[회원 탈퇴] |DELETE |/api/v1/members/{memberId}

--- a/member-api/src/docs/asciidoc/member-nickname-updated.adoc
+++ b/member-api/src/docs/asciidoc/member-nickname-updated.adoc
@@ -1,0 +1,61 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toc-title: 목차
+:toclevels: 4
+:sectlinks:
+:title: 회원 닉네임 수정
+
+//NOTE: ""
+//TIP: ""
+//IMPORTANT: ""
+//CAUTION: ""
+//WARNING: ""
+
+ifeval::["{snippets}/{docname}/curl-request.adoc" != ""]
+:snippets: build/generated-snippets
+
+= {title}
+
+== Request
+
+ifeval::["{snippets}/{docname}/curl-request.adoc" != ""]
+=== Curl-Request
+include::{snippets}/{docname}/curl-request.adoc[]
+endif::[]
+
+ifeval::["{snippets}/{docname}/http-request.adoc" != ""]
+=== Http-Request
+include::{snippets}/{docname}/http-request.adoc[]
+endif::[]
+
+ifeval::["{snippets}/{docname}/request-body.adoc" != ""]
+=== Request-Body
+include::{snippets}/{docname}/request-body.adoc[]
+endif::[]
+
+ifeval::["{snippets}/{docname}/request-parameters.adoc" == ""]
+=== Request-Parameters
+include::{snippets}/{docname}/request-parameters.adoc[]
+endif::[]
+
+== Response
+ifeval::["{snippets}/{docname}/http-response.adoc" != ""]
+=== Http-Response
+include::{snippets}/{docname}/http-response.adoc[]
+endif::[]
+
+ifeval::["{snippets}/{docname}/response-body.adoc" != ""]
+=== Response-Body
+include::{snippets}/{docname}/response-body.adoc[]
+endif::[]
+
+ifeval::["{snippets}/{docname}/response-fields.adoc" != ""]
+=== Response-Fields
+include::{snippets}/{docname}/response-fields.adoc[]
+endif::[]
+endif::[]
+
+=== link:index.html[전체 API 목록]
+=== link:member-api-index.html[Member API 목록]

--- a/member-api/src/main/java/com/kernelsquare/memberapi/common/config/CorsConfig.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/common/config/CorsConfig.java
@@ -16,7 +16,7 @@ public class CorsConfig implements WebMvcConfigurer {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-					.allowedOrigins("https://kernelsquare.live", "http://localhost:3000")
+					.allowedOrigins("https://kernelsquare.live", "http://dev.kernelsquare.live", "http://localhost:3000")
 					.allowCredentials(true)
 					.allowedHeaders("*")
 					.allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")

--- a/member-api/src/main/java/com/kernelsquare/memberapi/common/config/SecurityConfig.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/common/config/SecurityConfig.java
@@ -126,7 +126,7 @@ public class SecurityConfig {
 			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/profile").hasRole("USER")
 			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/password").hasRole("USER")
 			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/introduction").hasRole("USER")
-			.requestMatchers(HttpMethod.PUT, "/api/v1/members/nick").hasRole("USER")
+			.requestMatchers(HttpMethod.PUT, "/api/v1/members/nickname").hasRole("USER")
 			.requestMatchers(HttpMethod.POST, "/api/v1/questions/**").hasRole("USER")
 			.requestMatchers(HttpMethod.PUT, "/api/v1/questions/{questionId}").hasRole("USER")
 			.requestMatchers(HttpMethod.DELETE, "/api/v1/questions/{questionId}").hasRole("USER")

--- a/member-api/src/main/java/com/kernelsquare/memberapi/common/config/SecurityConfig.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/common/config/SecurityConfig.java
@@ -126,6 +126,7 @@ public class SecurityConfig {
 			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/profile").hasRole("USER")
 			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/password").hasRole("USER")
 			.requestMatchers(HttpMethod.PUT, "/api/v1/members/{memberId}/introduction").hasRole("USER")
+			.requestMatchers(HttpMethod.PUT, "/api/v1/members/nick").hasRole("USER")
 			.requestMatchers(HttpMethod.POST, "/api/v1/questions/**").hasRole("USER")
 			.requestMatchers(HttpMethod.PUT, "/api/v1/questions/{questionId}").hasRole("USER")
 			.requestMatchers(HttpMethod.DELETE, "/api/v1/questions/{questionId}").hasRole("USER")

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/controller/MemberController.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/controller/MemberController.java
@@ -63,7 +63,7 @@ public class MemberController {
 		return ResponseEntityFactory.toResponseEntity(MEMBER_DELETED);
 	}
 
-	@PutMapping("/members/nick")
+	@PutMapping("/members/nickname")
 	public ResponseEntity<ApiResponse<FindMemberResponse>> updateMemberNickname(
 			@Valid @RequestBody
 			UpdateMemberNicknameRequest updateNicknameRequest,

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/controller/MemberController.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/controller/MemberController.java
@@ -2,7 +2,10 @@ package com.kernelsquare.memberapi.domain.member.controller;
 
 import static com.kernelsquare.core.common_response.response.code.MemberResponseCode.*;
 
+import com.kernelsquare.memberapi.domain.auth.dto.MemberAdapter;
+import com.kernelsquare.memberapi.domain.member.dto.UpdateMemberNicknameRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,5 +61,14 @@ public class MemberController {
 	public ResponseEntity<ApiResponse> deleteMember(@PathVariable Long memberId) {
 		memberService.deleteMember(memberId);
 		return ResponseEntityFactory.toResponseEntity(MEMBER_DELETED);
+	}
+
+	@PutMapping("/members/nick")
+	public ResponseEntity<ApiResponse<FindMemberResponse>> updateMemberNickname(
+			@Valid @RequestBody
+			UpdateMemberNicknameRequest updateNicknameRequest,
+			@AuthenticationPrincipal MemberAdapter memberAdapter) {
+		FindMemberResponse response = memberService.updateMemberNickname(updateNicknameRequest, memberAdapter.getMember().getId());
+		return ResponseEntityFactory.toResponseEntity(MEMBER_NICKNAME_UPDATED, response);
 	}
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/dto/UpdateMemberNicknameRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/dto/UpdateMemberNicknameRequest.java
@@ -1,0 +1,14 @@
+package com.kernelsquare.memberapi.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record UpdateMemberNicknameRequest(
+        @NotNull(message = "변경시키고자 하는 회원 ID는 필수 입력사항입니다.")
+        Long memberId,
+        @NotBlank(message = "변경시키고자 하는 회원 닉네임은 필수 입력사항입니다.")
+        String nickname
+) {
+}

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/dto/UpdateMemberNicknameRequest.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/dto/UpdateMemberNicknameRequest.java
@@ -1,5 +1,7 @@
 package com.kernelsquare.memberapi.domain.member.dto;
 
+import com.kernelsquare.core.validation.annotations.BadWordFilter;
+import com.kernelsquare.core.validation.constants.BadWordValidationMessage;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -9,6 +11,7 @@ public record UpdateMemberNicknameRequest(
         @NotNull(message = "변경시키고자 하는 회원 ID는 필수 입력사항입니다.")
         Long memberId,
         @NotBlank(message = "변경시키고자 하는 회원 닉네임은 필수 입력사항입니다.")
+        @BadWordFilter(message = BadWordValidationMessage.NO_BAD_WORD_IN_CONTENT)
         String nickname
 ) {
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/service/MemberService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.kernelsquare.memberapi.domain.member.service;
 
+import com.kernelsquare.memberapi.domain.member.dto.UpdateMemberNicknameRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,5 +54,17 @@ public class MemberService {
 	private Member getMemberById(Long id) {
 		return memberRepository.findById(id)
 			.orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+	}
+
+	@Transactional
+	public FindMemberResponse updateMemberNickname(UpdateMemberNicknameRequest updateMemberNicknameRequest, Long memberId) {
+		Member member = getMemberById(memberId);
+
+		if (memberRepository.existsByNickname(updateMemberNicknameRequest.nickname())) {
+			throw new BusinessException(MemberErrorCode.ALREADY_SAVED_NICKNAME);
+		}
+
+		member.updateNickname(updateMemberNicknameRequest.nickname());
+		return FindMemberResponse.from(member);
 	}
 }

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/member/controller/MemberControllerTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/member/controller/MemberControllerTest.java
@@ -269,7 +269,7 @@ class MemberControllerTest extends RestDocsControllerTest {
 		given(memberService.updateMemberNickname(any(UpdateMemberNicknameRequest.class) ,anyLong())).willReturn(FindMemberResponse.from(testMember));
 		//when
 		ResultActions resultActions = mockMvc.perform(
-				RestDocumentationRequestBuilders.put("/api/v1/members/nick")
+				RestDocumentationRequestBuilders.put("/api/v1/members/nickname")
 						.with(csrf())
 						.with(user(memberAdapter))
 						.contentType(MediaType.APPLICATION_JSON)

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/member/service/MemberServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/member/service/MemberServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
+import com.kernelsquare.memberapi.domain.member.dto.UpdateMemberNicknameRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -254,6 +255,62 @@ public class MemberServiceTest {
 		verify(memberRepository, times(1)).findById(anyLong());
 	}
 
+	@Test
+	@DisplayName("회원 닉네임 수정 테스트")
+	void testUpdateMemberNickname() throws Exception {
+		//given
+		Long testMemberId = 1L;
+
+		String newNickname = "IamNewJeans";
+
+		UpdateMemberNicknameRequest updateMemberNicknameRequest = UpdateMemberNicknameRequest
+				.builder()
+				.memberId(1L)
+				.nickname(newNickname)
+				.build();
+
+		Member member = createTestMember();
+		Optional<Member> optionalMember = Optional.of(member);
+		Member updatedMember = Member.builder()
+				.nickname(newNickname)
+				.imageUrl(member.getImageUrl())
+				.level(member.getLevel())
+				.email(member.getEmail())
+				.authorities(member.getAuthorities())
+				.password(member.getPassword())
+				.build();
+		Optional<Member> optionalUpdatedMember = Optional.of(updatedMember);
+
+		doReturn(optionalMember)
+				.when(memberRepository)
+				.findById(anyLong());
+
+		memberService.updateMemberNickname(updateMemberNicknameRequest, testMemberId);
+
+		doReturn(optionalUpdatedMember)
+				.when(memberRepository)
+				.findById(anyLong());
+
+		//when
+		Optional<Member> optionalFoundMember = memberRepository.findById(testMemberId);
+
+//		FindMemberResponse findMemberResponse = memberService.findMember(testMemberId);
+
+		//then
+		assertThat(optionalFoundMember.get().getNickname()).isEqualTo(newNickname);
+
+//		assertThat(findMemberResponse.nickname()).isEqualTo(newNickname);
+//		assertThat(findMemberResponse.introduction()).isEqualTo(member.getIntroduction());
+//		assertThat(findMemberResponse.experience()).isEqualTo(member.getExperience());
+//		assertThat(findMemberResponse.imageUrl().length()).isGreaterThan(member.getImageUrl().length());
+//		assertThat(findMemberResponse.imageUrl()).endsWith(member.getImageUrl());
+//		assertThat(findMemberResponse.memberId()).isEqualTo(testMemberId);
+
+		//verify
+		verify(memberRepository, times(2)).findById(anyLong());
+	}
+
+
 	private Member createTestMember() {
 		return Member
 			.builder()
@@ -261,6 +318,7 @@ public class MemberServiceTest {
 			.nickname("hongjugwang")
 			.email("jugwang@naver.com")
 			.password("hashedPassword")
+			.level(Level.builder().id(1L).build())
 			.experience(10000L)
 			.introduction("hi, i'm hongjugwang.")
 			.imageUrl("s3:qwe12fasdawczx")

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/member/service/MemberServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/member/service/MemberServiceTest.java
@@ -294,17 +294,8 @@ public class MemberServiceTest {
 		//when
 		Optional<Member> optionalFoundMember = memberRepository.findById(testMemberId);
 
-//		FindMemberResponse findMemberResponse = memberService.findMember(testMemberId);
-
 		//then
 		assertThat(optionalFoundMember.get().getNickname()).isEqualTo(newNickname);
-
-//		assertThat(findMemberResponse.nickname()).isEqualTo(newNickname);
-//		assertThat(findMemberResponse.introduction()).isEqualTo(member.getIntroduction());
-//		assertThat(findMemberResponse.experience()).isEqualTo(member.getExperience());
-//		assertThat(findMemberResponse.imageUrl().length()).isGreaterThan(member.getImageUrl().length());
-//		assertThat(findMemberResponse.imageUrl()).endsWith(member.getImageUrl());
-//		assertThat(findMemberResponse.memberId()).isEqualTo(testMemberId);
 
 		//verify
 		verify(memberRepository, times(2)).findById(anyLong());


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #431 

## 개요
> 닉네임 수정 기능 추가

## 상세 내용
- 닉네임 수정 기능 추가
- 닉네임 중복 체크 로직 추가
- UpdateMemberNicknameRequest 에서 member_id 는 현재 프론트와 admin API 명세서 따라서 작성됨
- 테스트 코드 작성 및 Rest Doc 작성

++ CORS dev 도메인 추가
