### PR TITLE
[fix] github oauth2 redirect-uri 수정

### DIFF
--- a/member-api/src/main/resources/application.yml
+++ b/member-api/src/main/resources/application.yml
@@ -77,7 +77,7 @@ spring:
           github:
             client-id: ${SOCIAL_GITHUB_CLIENT_ID}
             client-secret: ${SOCIAL_GITHUB_CLIENT_SECRET}
-            redirect-uri: http://localhost:8501/login/oauth2/code/github
+            redirect-uri: http://dev-back.kernelsquare.live:8501/login/oauth2/code/github
             scope:
               - user:email
 


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [ ] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #444 

## 개요
> github oauth2 redirect-uri 수정하여 별칭 도메인을 맞추기 위함

## 상세 내용
- localhost는 숫자 IP
- localhost -> dev-back.kernelsquare.live
