### PR TITLE
[refactor] 채팅 서버에 만료 메시지를 보낼 수 있게 수정

### DIFF
--- a/member-api/src/main/resources/templates/chatscreen.html
+++ b/member-api/src/main/resources/templates/chatscreen.html
@@ -50,7 +50,7 @@
     var sender = /*[[${sender}]]*/ '';
     /*]]>*/
     //alert(document.title);
-    var sock = new SockJS("/kernel-square");
+    var sock = new SockJS("http://localhost:8504/kernel-square");
     var ws = Stomp.over(sock);
     var reconnect = 0;
     var vm = new Vue({
@@ -71,7 +71,7 @@
                     ('0' + now.getMinutes()).slice(-2) + ':' +
                     ('0' + now.getSeconds()).slice(-2) + '.' +
                     ('00' + now.getMilliseconds()).slice(-3) + 'Z';
-                ws.send("/app/chat/message", {}, JSON.stringify({type:'TALK', room_key:this.roomId, sender:this.sender, message:this.message, send_time:sendTime}));
+                ws.send("/app/chat/message", {}, JSON.stringify({type:'TALK', room_key:'dev', sender:this.sender, message:this.message, send_time:sendTime}));
                 this.message = '';
             },
             recvMessage: function(recv) {
@@ -86,7 +86,7 @@
                     ('0' + now.getMinutes()).slice(-2) + ':' +
                     ('0' + now.getSeconds()).slice(-2) + '.' +
                     ('00' + now.getMilliseconds()).slice(-3) + 'Z';
-                ws.send("/app/chat/message", {}, JSON.stringify({type:'LEAVE', room_key:this.roomId, sender:this.sender, send_time:sendTime}));
+                ws.send("/app/chat/message", {}, JSON.stringify({type:'LEAVE', room_key:'dev', sender:this.sender, send_time:sendTime}));
                 ws.disconnect();
             }
         }
@@ -111,7 +111,7 @@
             if(reconnect++ <= 5) {
                 setTimeout(function() {
                     console.log("connection reconnect");
-                    sock = new SockJS("/kernel-square");
+                    sock = new SockJS("http://localhost:8504/kernel-square");
                     ws = Stomp.over(sock);
                     connect();
                 },10*1000);


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [ ] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #456 

## 개요
> 채팅 서버 분리로 인한 만료 메시지 전송 스케줄러 변경이 필요

## 상세 내용
- 만료 메시지를 채팅 서버와 연결되어있는 kafka로 send하게끔 변경
- 테스트용 화면인 screen.html에서 sockJs 연결 대상을 dev-datahub로 할 수 있게끔 변경
