### PR TITLE
refactor: CoffeeChatService에서 인메모리로 관리하는 chatRoomMemberList 제거

### DIFF
--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/coffeechat/dto/EnterCoffeeChatRoomResponse.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/coffeechat/dto/EnterCoffeeChatRoomResponse.java
@@ -6,7 +6,6 @@ import com.kernelsquare.domainmysql.domain.coffeechat.entity.ChatRoom;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Builder
 public record EnterCoffeeChatRoomResponse(
@@ -16,21 +15,17 @@ public record EnterCoffeeChatRoomResponse(
 
 	Boolean active,
 
-	List<ChatRoomMember> memberList,
-
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = TimeResponseFormat.PATTERN)
 	LocalDateTime expirationTime
 ) {
 	public static EnterCoffeeChatRoomResponse of(
 		String articleTitle,
-		ChatRoom chatRoom,
-		List<ChatRoomMember> chatRoomMemberList
+		ChatRoom chatRoom
 	) {
 		return EnterCoffeeChatRoomResponse.builder()
 			.articleTitle(articleTitle)
 			.roomKey(chatRoom.getRoomKey())
 			.active(chatRoom.getActive())
-			.memberList(chatRoomMemberList)
 			.expirationTime(chatRoom.getExpirationTime())
 			.build();
 	}

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/coffeechat/controller/CoffeeChatControllerTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/coffeechat/controller/CoffeeChatControllerTest.java
@@ -137,10 +137,8 @@ class CoffeeChatControllerTest extends RestDocsControllerTest {
 
 		MemberAdapter memberAdapter = new MemberAdapter(MemberAdaptorInstance.of(member));
 
-		ChatRoomMember chatRoomMember = ChatRoomMember.from(member);
-
 		EnterCoffeeChatRoomResponse enterCoffeeChatRoomResponse = EnterCoffeeChatRoomResponse.of(
-			enterCoffeeChatRoomRequest.articleTitle(), chatRoom, List.of(chatRoomMember));
+			enterCoffeeChatRoomRequest.articleTitle(), chatRoom);
 
 		given(coffeeChatService.enterCoffeeChatRoom(any(EnterCoffeeChatRoomRequest.class),
 			any(MemberAdapter.class))).willReturn(enterCoffeeChatRoomResponse);
@@ -171,11 +169,6 @@ class CoffeeChatControllerTest extends RestDocsControllerTest {
 					fieldWithPath("data.article_title").type(JsonFieldType.STRING).description("게시글 제목"),
 					fieldWithPath("data.room_key").type(JsonFieldType.STRING).description("채팅방 키"),
 					fieldWithPath("data.active").type(JsonFieldType.BOOLEAN).description("활성화 여부"),
-					fieldWithPath("data.member_list").type(JsonFieldType.ARRAY).description("채팅방 멤버 리스트"),
-					fieldWithPath("data.member_list[].member_id").type(JsonFieldType.NUMBER).description("멤버 아이디"),
-					fieldWithPath("data.member_list[].nickname").type(JsonFieldType.STRING).description("멤버 닉네임"),
-					fieldWithPath("data.member_list[].member_image_url").type(JsonFieldType.STRING)
-						.description("멤버 이미지 URL"),
 					fieldWithPath("data.expiration_time").type(JsonFieldType.STRING).description("채팅방 만료 시간")
 				)));
 


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #475 

## 개요
> 입장하기를 할때 CoffeeChatService에서 인메모리에서 관리하는 chatRoomMemberList에 해당 멤버를 추가하는데, 나가기를 할 때 제거하는 로직이 없어서 입장 혹은 재입장할 때마다 chatRoomMemberList에 추가되어 인메모리에 계속 쌓이는 문제가 발생할 것 같아서 chatRoomMemberList를 제거

## 상세 내용
- CoffeeChatService 파일에서 chatRoomMemberList 제거
- chatRoomMemberList를 사용하는 로직들 수정
- ChatMessageRequest와 ChatMessageResponse 형태는 그대로 둠