### PR TITLE
[bugfix] 컨슈머와 프로듀서의 각 위치의 ChatMessageRequest를 인식하기 위한 KafkaProducerConfig 의 JsonSerializer에 ChatMessageRequest 매핑 추가

### DIFF
--- a/member-api/src/main/java/com/kernelsquare/memberapi/common/config/KafkaProducerConfig.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/common/config/KafkaProducerConfig.java
@@ -23,6 +23,7 @@ public class KafkaProducerConfig {
 		config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
 		config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 		config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+		config.put(JsonSerializer.TYPE_MAPPINGS, "ChatMessageRequest:com.kernelsquare.memberapi.domain.coffeechat.dto.ChatMessageRequest");
 		return new DefaultKafkaProducerFactory<>(config);
 	}
 


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #477 

## 개요
현재 채팅방 30분 만료 메시지를 member-api에서 카프카로 보내고 있는데, 이 때 카프카 메시지 헤더에 객체 클래스에 대한 정보가 들어있습니다.
그래서 chatting-api 서버의 카프카 컨슈머에서 member-api의 ChatMessageRequest와 같은 위치에서 ChatMessageRequest를 찾으려고 합니다.
하지만 member-api의 ChatMessageRequest와 chatting-api의 ChatMessageRequest 위치가 달라서 찾지못하고 역직렬화에 실패했다는 에러 로그를 출력하게 됩니다.
여기서 카프카의 기본 설정은 역직렬화에 실패한 메시지를 빠른 속도로 다시 역직렬화 시도를 하여 무한루프에 빠지게 됩니다.
그로인해 엄청나게 빠른 속도로 로그가 쌓이고 디스크 공간이 모자르게 됩니다.

## 상세 내용
- 프로듀서와 컨슈머에서의 위치가 다른 메시지 클래스는 각 config 파일에서 직접 mapping 해주는 방법으로 해결했습니다.
- 채팅 서버의 컨슈머 설정도 변경합니다.
