### PR TITLE
[refactor] 알림 메시지 데이터 구조 변경

### DIFF
--- a/domain-mongodb/build.gradle
+++ b/domain-mongodb/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
+    implementation project(':core')
+
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 

--- a/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/alert/entity/Alert.java
+++ b/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/alert/entity/Alert.java
@@ -1,18 +1,24 @@
 package com.kernelsquare.domainmongodb.domain.alert.entity;
 
+import com.kernelsquare.core.util.TokenGenerator;
 import io.micrometer.common.util.StringUtils;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.security.InvalidParameterException;
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Objects;
 
 @Getter
 @Document(collection = "alert")
 public class Alert {
+    private final String ALERT_PREFIX = "alt_";
+
     @Id
     private String id;
 
@@ -25,11 +31,11 @@ public class Alert {
 
     private String sender;
 
-    private String message;
-
     private AlertType alertType;
 
     private LocalDateTime sendTime;
+
+    private Map<String, String> payload;
 
     @Getter
     @RequiredArgsConstructor
@@ -40,7 +46,8 @@ public class Alert {
     }
 
     @Builder
-    public Alert(String recipientId, String recipient, String senderId, String sender, String message, AlertType alertType) {
+    public Alert(String recipientId, String recipient, String senderId, String sender, AlertType alertType,
+                 Map<String, String> payload) {
         if (StringUtils.isBlank(recipientId))
             throw new InvalidParameterException("Invalid recipientId");
         if (StringUtils.isBlank(recipient))
@@ -49,17 +56,16 @@ public class Alert {
             throw new InvalidParameterException("Invalid senderId");
         if (StringUtils.isBlank(sender))
             throw new InvalidParameterException("Invalid sender");
-        if (StringUtils.isBlank(message))
-            throw new InvalidParameterException("Invalid message");
         if (Objects.isNull(alertType))
             throw new InvalidParameterException("Invalid AlertType");
 
+        this.id = TokenGenerator.randomCharacterWithPrefix(ALERT_PREFIX);
         this.recipientId = recipientId;
         this.recipient = recipient;
         this.senderId = senderId;
         this.sender = sender;
-        this.message = message;
         this.alertType = alertType;
         this.sendTime = LocalDateTime.now();
+        this.payload = payload;
     }
 }

--- a/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/answer/info/AnswerInfo.java
+++ b/domain-mysql/src/main/java/com/kernelsquare/domainmysql/domain/answer/info/AnswerInfo.java
@@ -12,6 +12,7 @@ public class AnswerInfo {
     private final String recipient;
     private final String senderId;
     private final String sender;
+    private final String questionId;
     private final String questionTitle;
 
     public static AnswerInfo from(Question question, Member answerAuthor) {
@@ -20,6 +21,7 @@ public class AnswerInfo {
             .recipient(question.getMember().getNickname())
             .senderId(answerAuthor.getId().toString())
             .sender(answerAuthor.getNickname())
+            .questionId(question.getId().toString())
             .questionTitle(question.getTitle())
             .build();
     }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/alert/dto/AlertDto.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/alert/dto/AlertDto.java
@@ -10,15 +10,17 @@ public class AlertDto {
     public record RankAnswerAlert(
         String recipientId,
         String recipient,
+        String questionId,
         String questionTitle,
-        String rankName
+        String rank
     ) {
         public static RankAnswerAlert of(Question question, Answer answer, Rank rank) {
             return RankAnswerAlert.builder()
                 .recipientId(answer.getMember().getId().toString())
                 .recipient(answer.getMember().getNickname())
+                .questionId(question.getId().toString())
                 .questionTitle(question.getTitle())
-                .rankName(rank.getName().toString())
+                .rank(rank.getName().toString())
                 .build();
         }
     }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/alert/dto/CoffeeChatRequestAlertMessage.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/alert/dto/CoffeeChatRequestAlertMessage.java
@@ -3,6 +3,9 @@ package com.kernelsquare.memberapi.domain.alert.dto;
 import com.kernelsquare.domainmongodb.domain.alert.entity.Alert;
 import lombok.Builder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Builder
 public class CoffeeChatRequestAlertMessage implements AlertMessage {
     private final String recipientId;
@@ -12,13 +15,18 @@ public class CoffeeChatRequestAlertMessage implements AlertMessage {
 
     @Override
     public Alert process() {
+        Map<String, String> payload = new HashMap<>(Map.of(
+            "senderId", senderId,
+            "sender", sender
+        ));
+
         return Alert.builder()
             .recipientId(recipientId)
             .recipient(recipient)
             .senderId(senderId)
             .sender(sender)
-            .message("커피챗 요청이 들어왔습니다.")
             .alertType(Alert.AlertType.COFFEE_CHAT_REQUEST)
+            .payload(payload)
             .build();
     }
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/alert/dto/QuestionReplyAlertMessage.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/alert/dto/QuestionReplyAlertMessage.java
@@ -3,23 +3,33 @@ package com.kernelsquare.memberapi.domain.alert.dto;
 import com.kernelsquare.domainmongodb.domain.alert.entity.Alert;
 import lombok.Builder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Builder
 public class QuestionReplyAlertMessage implements AlertMessage {
     private final String recipientId;
     private final String recipient;
     private final String senderId;
     private final String sender;
+    private final String questionId;
     private final String questionTitle;
 
     @Override
     public Alert process() {
+        Map<String, String> payload = new HashMap<>(Map.of(
+            "questionId", questionId,
+            "questionTitle", questionTitle,
+            "sender", sender
+        ));
+
         return Alert.builder()
             .recipientId(recipientId)
             .recipient(recipient)
             .senderId(senderId)
             .sender(sender)
-            .message(questionTitle + " 글에 " + sender + "님이 답변했습니다.")
             .alertType(Alert.AlertType.QUESTION_REPLY)
+            .payload(payload)
             .build();
     }
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/alert/dto/RankAnswerAlertMessage.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/alert/dto/RankAnswerAlertMessage.java
@@ -4,22 +4,32 @@ import com.kernelsquare.core.constants.SystemConstants;
 import com.kernelsquare.domainmongodb.domain.alert.entity.Alert;
 import lombok.Builder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Builder
 public class RankAnswerAlertMessage implements AlertMessage {
     private String recipientId;
     private String recipient;
+    private String questionId;
     private String questionTitle;
-    private String rankName;
+    private String rank;
 
     @Override
     public Alert process() {
+        Map<String, String> payload = new HashMap<>(Map.of(
+            "questionId", questionId,
+            "questionTitle", questionTitle,
+            "rank", rank
+        ));
+
         return Alert.builder()
             .recipientId(recipientId)
             .recipient(recipient)
             .senderId(SystemConstants.ALERT_SYSTEM)
             .sender(SystemConstants.ALERT_SYSTEM)
-            .message(questionTitle + " 글에 작성하신 답변이 " + rankName + "등 답변이 되었습니다.")
             .alertType(Alert.AlertType.RANK_ANSWER)
+            .payload(payload)
             .build();
     }
 }

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/answer/service/AnswerServiceTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/answer/service/AnswerServiceTest.java
@@ -105,8 +105,6 @@ public class AnswerServiceTest {
 		//given
 		Long foundMemberId = 1L;
 
-		Long foundQuestionId = 1L;
-
 		Long foundTestAnswerId = 1L;
 
 		Long memberId = 2L; // 본인 질문에 답변 달 수 없기에 foundMemberId 와 다르게 설정
@@ -122,7 +120,7 @@ public class AnswerServiceTest {
 		Answer foundAnswer = createTestAnswer(foundTestAnswerId, 1L, foundMember, foundQuestion);
 
 		AnswerCommand.CreateAnswer command = AnswerCommand.CreateAnswer.builder()
-			.questionId(foundQuestionId)
+			.questionId(foundQuestion.getId())
 			.content(foundAnswer.getContent())
 			.imageUrl(foundAnswer.getImageUrl())
 			.author(foundMember)
@@ -142,6 +140,7 @@ public class AnswerServiceTest {
 		assertThat(answerInfo.getRecipient()).isEqualTo(foundQuestion.getMember().getNickname());
 		assertThat(answerInfo.getSenderId()).isEqualTo(foundAnswer.getMember().getId().toString());
 		assertThat(answerInfo.getSender()).isEqualTo(foundAnswer.getMember().getNickname());
+		assertThat(answerInfo.getQuestionId()).isEqualTo(foundQuestion.getId().toString());
 		assertThat(answerInfo.getQuestionTitle()).isEqualTo(foundQuestion.getTitle());
 
 		//verify
@@ -218,6 +217,7 @@ public class AnswerServiceTest {
 	private Question createTestQuestion() {
 		return Question
 			.builder()
+			.id(2131231L)
 			.title("Test Question")
 			.content("Test Content")
 			.imageUrl("S3:TestImage")


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #482 

## 개요
> 화면에 뿌리는데 필요한 데이터는 넣고 불필요한 데이터는 빼고 응답으로 주기 위함

## 상세 내용
- AlertMessage는 메시지의 멤버 변수는 공통으로 사용하는 것이고 payload는 해당 메시지에만 사용하는 데이터를 넣는 형태로 구현
