### PR TITLE
[refactor] chatGPT가 답변을 달 때도 질문 작성자에게 알림이 가도록 수정

### DIFF
--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/answer/controller/AnswerController.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/answer/controller/AnswerController.java
@@ -8,8 +8,7 @@ import com.kernelsquare.memberapi.domain.answer.dto.UpdateAnswerRequest;
 import com.kernelsquare.memberapi.domain.answer.facade.AnswerFacade;
 import com.kernelsquare.memberapi.domain.answer.service.AnswerService;
 import com.kernelsquare.memberapi.domain.auth.dto.MemberAdapter;
-import com.kernelsquare.memberapi.domain.chatgpt.service.ChatGptService;
-
+import com.kernelsquare.memberapi.domain.chatgpt.facade.ChatGptFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +24,7 @@ public class AnswerController {
 
 	private final AnswerService answerService;
 	private final AnswerFacade answerFacade;
-	private final ChatGptService chatGptService;
+	private final ChatGptFacade chatGptFacade;
 
 	@GetMapping("/questions/{questionId}/answers")
 	public ResponseEntity<ApiResponse<FindAllAnswerResponse>> findAllAnswer(
@@ -49,7 +48,7 @@ public class AnswerController {
 	public ResponseEntity<ApiResponse> createAnswerWithChatGpt(
 		@PathVariable Long questionId
 	) {
-		chatGptService.createChatGptAnswer(questionId);
+		chatGptFacade.createChatGptAnswer(questionId);
 		return ResponseEntityFactory.toResponseEntity(AUTOMATED_ANSWER_CREATED);
 	}
 

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/chatgpt/facade/ChatGptFacade.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/chatgpt/facade/ChatGptFacade.java
@@ -1,0 +1,21 @@
+package com.kernelsquare.memberapi.domain.chatgpt.facade;
+
+import com.kernelsquare.domainmysql.domain.answer.info.AnswerInfo;
+import com.kernelsquare.memberapi.domain.alert.mapper.AlertDtoMapper;
+import com.kernelsquare.memberapi.domain.alert.service.AlertService;
+import com.kernelsquare.memberapi.domain.chatgpt.service.ChatGptService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatGptFacade {
+    private final ChatGptService chatGptService;
+    private final AlertService alertService;
+    private final AlertDtoMapper alertDtoMapper;
+
+    public void createChatGptAnswer(Long questionId) {
+        AnswerInfo answerInfo = chatGptService.createChatGptAnswer(questionId);
+        alertService.sendToBroker(alertDtoMapper.from(answerInfo));
+    }
+}

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/chatgpt/service/ChatGptService.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/chatgpt/service/ChatGptService.java
@@ -1,5 +1,7 @@
 package com.kernelsquare.memberapi.domain.chatgpt.service;
 
+import com.kernelsquare.domainmysql.domain.answer.info.AnswerInfo;
+
 public interface ChatGptService {
-	void createChatGptAnswer(Long questionId);
+	AnswerInfo createChatGptAnswer(Long questionId);
 }

--- a/member-api/src/main/java/com/kernelsquare/memberapi/domain/chatgpt/service/ChatGptServiceImpl.java
+++ b/member-api/src/main/java/com/kernelsquare/memberapi/domain/chatgpt/service/ChatGptServiceImpl.java
@@ -3,6 +3,7 @@ package com.kernelsquare.memberapi.domain.chatgpt.service;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import com.kernelsquare.domainmysql.domain.answer.info.AnswerInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,7 +41,7 @@ public class ChatGptServiceImpl implements ChatGptService {
 	@SneakyThrows({URISyntaxException.class})
 	@Transactional
 	@Override
-	public void createChatGptAnswer(Long questionId) {
+	public AnswerInfo createChatGptAnswer(Long questionId) {
 		if (answerRepository.existsByMemberNicknameAndQuestionId(KernelSquareBotConstants.KERNEL_SQUARE_AI_INTERN, questionId)) {
 			throw new BusinessException(KernelSquareBotErrorCode.ANSWER_ALREADY_EXIST);
 		}
@@ -67,5 +68,7 @@ public class ChatGptServiceImpl implements ChatGptService {
 			.build();
 
 		answerRepository.save(answer);
+
+		return AnswerInfo.from(question, member);
 	}
 }

--- a/member-api/src/test/java/com/kernelsquare/memberapi/domain/answer/controller/AnswerControllerTest.java
+++ b/member-api/src/test/java/com/kernelsquare/memberapi/domain/answer/controller/AnswerControllerTest.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.kernelsquare.memberapi.domain.chatgpt.facade.ChatGptFacade;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -114,7 +115,7 @@ class AnswerControllerTest extends RestDocsControllerTest {
 	@MockBean
 	private AnswerService answerService;
 	@MockBean
-	private ChatGptService chatGptService;
+	private ChatGptFacade chatGptFacade;
 	private List<FindAnswerResponse> answerResponseList = new ArrayList<>();
 	private FindAllAnswerResponse answerResponseListDto;
 	@MockBean


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #492 

## 개요
> chatGPT가 답변을 달 때도 질문 작성자에게 알림이 가도록 수정하기 위해 chatGptService와 alertService를 사용하는 chatGptFacade를 만들어 anaswer 컨트롤러에 사용

## 상세 내용
- 기존 AnswerInfo와 AlertDtoMapper를 사용하여 코드 구현
